### PR TITLE
set version number to 1.0.0 for jsk_common

### DIFF
--- a/rospatlite/package.xml
+++ b/rospatlite/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>rospatlite</name>
-  <version>0.0.1</version>
+  <version>1.0.0</version>
   <description>
      rospatlite
   </description>


### PR DESCRIPTION
bloom的におなじパッケージの下は全部同じバージョン番号ということで，１．０．０に揃えました．
https://github.com/jsk-ros-pkg/jsk_common/pull/282 
