### PR TITLE
modify to pass catkin_make, change remained old package name to new one

### DIFF
--- a/rospatlite/catkin.cmake
+++ b/rospatlite/catkin.cmake
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rospatlite)
 
+find_package(catkin REQUIRED)
+
 catkin_package(
   DEPENDS
   CATKIN_DEPENDS std_msgs rospy

--- a/rospatlite/scripts/patlite_node.py
+++ b/rospatlite/scripts/patlite_node.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
-import roslib; roslib.load_manifest('patlite')
+try: # catkin does not requires load_manifest
+    import rospatlite
+except:
+    import roslib; roslib.load_manifest('rospatlite')
 
 import rospy
 from std_msgs.msg import Int8


### PR DESCRIPTION
- catkin.cmakeにcatkinのdependが含まれていなかったのを修正。rosのdeb buildが通っていなかったのはこれのせい？
- patlite_node.pyの中で古いパッケージ名を使っていたのを修正。それとともにcatkinではload_manifestがいらないようなのでhrpsys_ros_bridge内の.pyを参考に修正。
