### PR TITLE
need to set $ROS_DISTRO

### DIFF
--- a/jsk.rosbuild
+++ b/jsk.rosbuild
@@ -115,7 +115,7 @@ function install-pkg {
         (mkdir -p $ROS_INSTALLDIR_SRC && cd $ROS_INSTALLDIR_SRC; catkin_init_workspace)
         (mkdir -p $ROS_INSTALLDIR_SRC && cd $ROS_INSTALLDIR_SRC && ( [ -f .rosinstall ] || ( wstool init ) ) && for ROSINSTALL in $@; do ROS_WORKSPACE="" wstool merge $ROSINSTALL -r -y ; done  )
     fi
-    
+
     success=0
     retry=0
     while [ $success == 0 -a $retry -lt 10 ]; do
@@ -126,11 +126,11 @@ function install-pkg {
         fi
         retry=`expr $retry + 1`
     done
-    
+
     echo "hddtemp hddtemp/daemon boolean false" | sudo debconf-set-selections
     # rosdep install
     (cd $ROS_INSTALLDIR_SRC &&
-        wget https://raw.github.com/jsk-ros-pkg/jsk_common/master/rosdep-update.sh -O - | bash)
+        wget https://raw.github.com/jsk-ros-pkg/jsk_common/master/rosdep-update.sh -O - | ROS_DISTRO=$DISTRIBUTION bash)
     return 0
 }
 


### PR DESCRIPTION
jsk.rosbuildで`rosdep install`するときに`$ROS_DISTRO`が設定されていないので，jsk.rosbuild内で呼ばれるrosdep-update.shの中の`rosdep install -r -n --from-paths . --ignore-src --rosdistro $ROS_DISTRO -y`が正しく動きません．

rosdep-update.shを呼ぶ際にjsk.rosbuild内の`$DISTRIBUTION`を`$ROS_DISTRO`に渡してあげる必要があると思います．
