### PR TITLE
Fix points rectangle extractor groovy catkin

### DIFF
--- a/jsk_ros_patch/image_view2/catkin.cmake
+++ b/jsk_ros_patch/image_view2/catkin.cmake
@@ -8,9 +8,8 @@ add_message_files(
   FILES ImageMarker2.msg PointArrayStamped.msg
 )
 
-generate_messages(DEPENDENCIES geometry_msgs std_msgs)
 
-## 
+
 include_directories(include ${catkin_INCLUDE_DIRS})
 
 # Image viewers
@@ -27,6 +26,8 @@ find_package(PCL REQUIRED)
 include_directories(${PCL_INCLUDE_DIRS})
 target_link_libraries(points_rectangle_extractor ${Boost_LIBRARIES} ${catkin_LIBRARIES})
 add_dependencies(points_rectangle_extractor ${PROJECT_NAME}_gencpp)
+
+generate_messages(DEPENDENCIES geometry_msgs std_msgs)
 
 catkin_package(
     DEPENDS OpenCV PCL


### PR DESCRIPTION
this PR is a patch to avoid the bug mentioned here https://github.com/jsk-ros-pkg/jsk_common/issues/331

this is just a hack and we should fix roseus.cmake.
- call generate_messages at the end of catkin.cmake and before `catkin_package()`.

If we call that function before using `${catkin_*}` variables, they will be empty.
