### PR TITLE
[jsk_topic_tools] avoid emtpy catkin variables problem

### DIFF
--- a/jsk_topic_tools/catkin.cmake
+++ b/jsk_topic_tools/catkin.cmake
@@ -12,6 +12,14 @@ add_service_files(
   FILES List.srv Update.srv
 )
 
+#include_directories(${Boost_INCLUDE_DIRS})
+add_executable(topic_buffer_server src/topic_buffer_server.cpp)
+add_executable(topic_buffer_client src/topic_buffer_client.cpp)
+add_dependencies(topic_buffer_server ${PROJECT_NAME}_gencpp)
+add_dependencies(topic_buffer_client ${PROJECT_NAME}_gencpp)
+target_link_libraries(topic_buffer_server ${catkin_LIBRARIES})
+target_link_libraries(topic_buffer_client ${catkin_LIBRARIES})
+
 generate_messages()
 
 catkin_package(
@@ -20,14 +28,6 @@ catkin_package(
     INCLUDE_DIRS
     LIBRARIES
 )
-
-#include_directories(${Boost_INCLUDE_DIRS})
-add_executable(topic_buffer_server src/topic_buffer_server.cpp)
-add_executable(topic_buffer_client src/topic_buffer_client.cpp)
-add_dependencies(topic_buffer_server ${PROJECT_NAME}_gencpp)
-add_dependencies(topic_buffer_client ${PROJECT_NAME}_gencpp)
-target_link_libraries(topic_buffer_server ${catkin_LIBRARIES})
-target_link_libraries(topic_buffer_client ${catkin_LIBRARIES})
 
 add_rostest(test/test_topic_buffer.test)
 add_rostest(test/test_topic_buffer_close_wait.test)


### PR DESCRIPTION
similar patch to https://github.com/jsk-ros-pkg/jsk_common/pull/332

move the location of `generate_messages` and `catkin_package` to avoid catkin empty variables
problem caused by roseus message generation.
