### PR TITLE
Added missing cmake_minimum_version to CMakeLists

### DIFF
--- a/jsk_tools/CMakeLists.txt
+++ b/jsk_tools/CMakeLists.txt
@@ -1,4 +1,5 @@
 if(NOT USE_ROSBUILD)
+  cmake_minimum_required(VERSION 2.8.3)
   project(jsk_tools)
 
   find_package(catkin REQUIRED)


### PR DESCRIPTION
This blocks builds on Fedora
