### PR TITLE
Added support for YAML-CPP 0.5+.

### DIFF
--- a/jsk_ros_patch/multi_map_server/src/main.cpp
+++ b/jsk_ros_patch/multi_map_server/src/main.cpp
@@ -47,6 +47,16 @@
 #include "nav_msgs/MapMetaData.h"
 #include "yaml-cpp/yaml.h"
 
+#ifdef HAVE_NEW_YAMLCPP
+// The >> operator disappeared in yaml-cpp 0.5, so this function is
+// added to provide support for code written under the yaml-cpp 0.3 API.
+template<typename T>
+void operator >> (const YAML::Node& node, T& i)
+{
+  i = node.as<T>();
+}
+#endif
+
 class MapServer
 {
   public:
@@ -69,9 +79,14 @@ class MapServer
           ROS_ERROR("Map_server could not open %s.", fname.c_str());
           exit(-1);
         }
-        YAML::Parser parser(fin);   
+#ifdef HAVE_NEW_YAMLCPP
+        // The document loading process changed in yaml-cpp 0.5.
+        YAML::Node doc = YAML::Load(fin);
+#else
+        YAML::Parser parser(fin);
         YAML::Node doc;
         parser.GetNextDocument(doc);
+#endif
         try { 
           doc["resolution"] >> res; 
         } catch (YAML::InvalidScalar) { 


### PR DESCRIPTION
The new yaml-cpp API removes the "node >> outputvar;" operator, and it has a new way of loading documents. There's no version hint in the library's headers, so I'm getting the version number from pkg-config.

See https://github.com/ros-planning/navigation/commit/6c82fb01340ec49b68c47b9c34beb47824782a20
