### PR TITLE
change arg name and node name

### DIFF
--- a/jsk_topic_tools/launch/tf_buffer_client.launch
+++ b/jsk_topic_tools/launch/tf_buffer_client.launch
@@ -1,12 +1,12 @@
 <launch>
   <arg name="PREFIX" default="tf_buffer"/>
-  <arg name="TF_REMOTE" default="/tf_low_frequency"/>
+  <arg name="REMOTE_TF" default="/tf_low_frequency"/>
   <group ns="$(arg PREFIX)">
-    <node pkg="jsk_topic_tools" type="topic_buffer_client" name="tf_buffer_client"
+    <node pkg="jsk_topic_tools" type="topic_buffer_client" name="$(anon tf_buffer_client)"
 	  output="screen">
       <remap from="/list" to="list"/>
       <remap from="/update" to="update"/>
-      <remap from="tf_merged_buffered" to="$(arg TF_REMOTE)"/>
+      <remap from="tf_merged_buffered" to="$(arg REMOTE_TF)"/>
       <rosparam>
         use_service: false
         topics: ["tf_merged"]


### PR DESCRIPTION
Change arg name.
Use anon node name in order to use tf_buffer_client in multiple clients.
