### PR TITLE
add -r (continue dispite errors) in rosdep install euslisp

### DIFF
--- a/jsk.rosbuild
+++ b/jsk.rosbuild
@@ -264,7 +264,7 @@ EOF
 function install-jsk-ros-pkg {
     wget  'https://raw.github.com/jsk-ros-pkg/jsk_common/master/jsk.rosinstall' -O /tmp/jsk.rosinstall.$$
     install-pkg /tmp/jsk.rosinstall.$$
-    rosdep install euslisp
+    rosdep install -y $package -v -r -i # y: default-yes, v: verbose, r: continue despite errors, i: ignore packages
     if [ "$DISPLAY" != "" ] && [ "`xset -q fp | grep /usr/share/fonts/X11/100dpi`" == "" ]; then
         xset +fp /usr/share/fonts/X11/100dpi,/usr/share/fonts/X11/75dpi || return 0
     fi


### PR DESCRIPTION
this blocks jsk.rosbuild -> http://jenkins.jsk.imi.i.u-tokyo.ac.jp:8080/job/jsk.rosbuild/DEBIAN_REPOSITORY=ros,FULL_SOURCE=full_source,ROS_DISTRO=groovy,slave=ec2/26/consoleFull
