### PR TITLE
Only run Makefile during build phase (not install)

### DIFF
--- a/3rdparty/libsiftfast/CMakeLists.txt
+++ b/3rdparty/libsiftfast/CMakeLists.txt
@@ -4,6 +4,8 @@ project(libsiftfast)
 find_package(catkin)
 
 add_custom_target(libsiftfast ALL
+  DEPENDS ${CATKIN_DEVEL_PREFIX}/lib/libsiftfast.so)
+add_custom_command(OUTPUT ${CATKIN_DEVEL_PREFIX}/lib/libsiftfast.so
   DEPENDS Makefile
   COMMAND  make -f ${PROJECT_SOURCE_DIR}/Makefile INSTALL_DIR=${CATKIN_DEVEL_PREFIX})
 


### PR DESCRIPTION
Currently, `Makefile` is re-run when catkin installs the package. This causes `Makefile` to re-install, this time leaving the files in `/` instead of an intermediate directory. This patch ensures that once built, `Makefile` is not re-run.

There are currently a bunch of files being installed to `/` in Fedora and probably in Ubuntu, too.
