### PR TITLE
fix for buildpakcage: use install(CODE for libraries, since library file...

### DIFF
--- a/3rdparty/libsiftfast/CMakeLists.txt
+++ b/3rdparty/libsiftfast/CMakeLists.txt
@@ -29,17 +29,24 @@ endif()
 install(PROGRAMS ${CATKIN_DEVEL_PREFIX}/bin/siftfast
         DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
 
-file(GLOB _libs ${CATKIN_DEVEL_PREFIX}/lib/libsiftfast.*)
-install(FILES ${_libs}
-        DESTINATION ${CATKIN_GLOBAL_LIB_DESTINATION})
+install(CODE "
+  file(GLOB _libs ${CATKIN_DEVEL_PREFIX}/lib/libsiftfast.*)
+  foreach(_lib \${_libs})
+    FILE(INSTALL DESTINATION \"\${CMAKE_INSTALL_PREFIX}/lib\" TYPE PROGRAM FILES \"\${_lib}\" )
+  endforeach()
+")
 
 install(DIRECTORY ${CATKIN_DEVEL_PREFIX}/include/siftfast
         DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 
-install(DIRECTORY ${CATKIN_DEVEL_PREFIX}/share/siftfast
-        DESTINATION ${CATKIN_GLOBAL_SHARE_DESTINATION}
+install(DIRECTORY ${CATKIN_DEVEL_PREFIX}/share/siftfast/
+        DESTINATION ${CATKIN_GLOBAL_SHARE_DESTINATION}/libsiftfast
         USE_SOURCE_PERMISSIONS)
 
+# only for deb packaging...
+if ($ENV{DH_OPTIONS}) # deb package need to remove generated files
+  install(CODE "execute_process(COMMAND cmake -E remove_directory ${CATKIN_DEVEL_PREFIX}")
+endif()
 
 
 


### PR DESCRIPTION
... is generated during compile phase; remove devel directory when dhbuild; install share/siftfast -> share/libsiftfast
