### PR TITLE
Added octmap repository for alternative to alfur-ros-pkg

### DIFF
--- a/jsk.rosinstall
+++ b/jsk.rosinstall
@@ -111,4 +111,13 @@
     uri: https://github.com/ros-visualization/view_controller_msgs.git
     version: hydro-devel
 
-    
+# octomap
+- git:
+    local-name: octomap_stacks/octomap_mapping
+    uri: https://github.com/OctoMap/octomap_mapping.git
+- git:
+    local-name: octomap_stacks/octomap_msgs
+    uri: https://github.com/OctoMap/octomap_msgs.git
+- git:
+    local-name: octomap_stacks/octomap_ros
+    uri: https://github.com/OctoMap/octomap_ros.git


### PR DESCRIPTION
Add OctoMap repository for alternatives to the old alfur-ros-pkg, which cause some problem in verison of humanoid_msgs and duplication of humoanoid_stacks
