### PR TITLE
change PS1 to show current MASTER_URI

### DIFF
--- a/jsk_tools/src/bashrc.ros
+++ b/jsk_tools/src/bashrc.ros
@@ -4,6 +4,10 @@ function rossetrobot() { # 自分のよく使うロボットのhostnameを入れ
     local hostname=${1-"pr1040"}
     local ros_port=${2-"11311"}
     export ROS_MASTER_URI=http://$hostname:$ros_port
+    if [[ "${PS1}" =~ \[http://.*:.*\]\ (.*)$ ]] ; then
+        export PS1="${BASH_REMATCH[1]}"
+    fi
+    export PS1="\[\033[00;31m\][$ROS_MASTER_URI]\[\033[00m\] ${PS1}"
     echo -e "\e[1;31mset ROS_MASTER_URI to $ROS_MASTER_URI\e[m"
 }
 


### PR DESCRIPTION
> であれば，ターミナルにmasterが表示されるようになっているほうがよかったりするだろうか．baxterコマンドはそうなっていますね．
> https://github.com/RethinkRobotics/baxter/blob/master/baxter.sh
> ターミナルにでるようになると、すごくいいですね。

は以下でしょうか？ ROS_IPも表示させる？色はこれでいい？

```
$ rossetrobot pr3
set ROS_MASTER_URI to http://pr3:11311
[http://pr3:11311] k-okada@kokada-t430s:~/catkin_ws/ws_jsk_common/src/jsk_common$ 
```

みたいになります．
