### PR TITLE
use geometry package to install orocos_kdl, since orocos_kdl is not installed

### DIFF
--- a/jsk_ros_patch/openni_tracker_jsk_patch/package.xml
+++ b/jsk_ros_patch/openni_tracker_jsk_patch/package.xml
@@ -12,7 +12,7 @@
 
   <author>Yohei Kakiuchi</author>
 
-  <build_depend>orocos_kdl</build_depend>
+  <build_depend>geometry</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>roslib</build_depend>


### PR DESCRIPTION
via rosdep https://github.com/ros/rosdistro/pull/4336
