### PR TITLE
Mkdir include dir in nlopt package failed.

### DIFF
--- a/3rdparty/nlopt/CMakeLists.txt
+++ b/3rdparty/nlopt/CMakeLists.txt
@@ -2,5 +2,5 @@ project(nlopt)
 
 cmake_minimum_required(VERSION 2.4.6)
 
-message("cmake -E chdir ${PROJECT_SOURCE_DIR} make -f ${PROJECT_SOURCE_DIR}/Makefile")
-execute_process(COMMAND cmake -E chdir ${PROJECT_SOURCE_DIR} make -f ${PROJECT_SOURCE_DIR}/Makefile)
+message("cmake -E chdir ${PROJECT_SOURCE_DIR} make -f ${PROJECT_SOURCE_DIR}/Makefile DSTDIR=${PROJECT_SOURCE_DIR}")
+execute_process(COMMAND cmake -E chdir ${PROJECT_SOURCE_DIR} make -f ${PROJECT_SOURCE_DIR}/Makefile DSTDIR=${PROJECT_SOURCE_DIR})

--- a/3rdparty/nlopt/Makefile
+++ b/3rdparty/nlopt/Makefile
@@ -5,11 +5,11 @@ TARBALL_URL = http://ab-initio.mit.edu/nlopt/nlopt-2.3.tar.gz
 SOURCE_DIR = build/nlopt-2.3
 MD5SUM_FILE = nlopt-2.3.tar.gz.md5sum
 UNPACK_CMD = tar xzf
-DESTDIR=$(shell rospack find nlopt)
+DSTDIR = $(PWD)
 include $(shell rospack find mk)/download_unpack_build.mk
 
 installed: $(SOURCE_DIR)/unpacked
-	cd $(SOURCE_DIR) && ./configure --enable-shared --with-cxx --prefix=$(DESTDIR) && make install
+	cd $(SOURCE_DIR) && ./configure --enable-shared --with-cxx --prefix=$(DSTDIR) && make install
 	touch installed
 clean:
 	-rm -rf include lib share $(SOURCE_DIR) installed

--- a/3rdparty/nlopt/manifest.xml
+++ b/3rdparty/nlopt/manifest.xml
@@ -1,5 +1,5 @@
 <package>
-  <description brief="nplot">
+  <description brief="nlopt">
 
      nlopt
 


### PR DESCRIPTION
Nlopt catkinize #457 failed to generate include directory although build itself succeeded.
The reason of this problem seems to me that `rospack find nlopt` in Makefile  returns empy string.

In this pull request, I remove rospack term, and instead, use PROJECT_SOURCE_DIR value in CMakelists.txt for detecting nlopt package directory.
