### PR TITLE
nlopt generate config.cmake for detecing nlopt package from eus_nlopt

### DIFF
--- a/3rdparty/nlopt/CMakeLists.txt
+++ b/3rdparty/nlopt/CMakeLists.txt
@@ -1,3 +1,8 @@
+if(NOT USE_ROSBUILD)
+  include(catkin.cmake)
+  return()
+endif()
+
 project(nlopt)
 
 cmake_minimum_required(VERSION 2.4.6)

--- a/3rdparty/nlopt/catkin.cmake
+++ b/3rdparty/nlopt/catkin.cmake
@@ -1,0 +1,28 @@
+project(nlopt)
+
+cmake_minimum_required(VERSION 2.4.6)
+
+find_package(catkin)
+
+message("cmake -E chdir ${PROJECT_SOURCE_DIR} make -f ${PROJECT_SOURCE_DIR}/Makefile DSTDIR=${PROJECT_SOURCE_DIR}")
+execute_process(COMMAND cmake -E chdir ${PROJECT_SOURCE_DIR} make -f ${PROJECT_SOURCE_DIR}/Makefile DSTDIR=${PROJECT_SOURCE_DIR})
+
+catkin_package(
+    DEPENDS
+    CATKIN-DEPENDS
+    INCLUDE_DIRS
+    LIBRARIES
+)
+
+# set(NLOPTDIR ${CATKIN_PACKAGE_SHARE_DESTINATION}/jskeus/eus)
+# install(CODE "message(\"-- Force change Cflags of \$ENV{DESTDIR}/\${CMAKE_INSTALL_PREFIX}/${CATKIN_PACKAGE_LIB_DESTINATION}/pkgconfig/euslisp.pc \$ENV{DESTDIR}/\${CMAKE_INSTALL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/cmake/\${PROJECT_NAME}Config.cmake\") execute_process(COMMAND sed -i s@\${CMAKE_INSTALL_PREFIX}/include@\${CMAKE_INSTALL_PREFIX}/${EUSDIR}/include@ \$ENV{DESTDIR}/\${CMAKE_INSTALL_PREFIX}/${CATKIN_PACKAGE_LIB_DESTINATION}/pkgconfig/euslisp.pc \$ENV{DESTDIR}/\${CMAKE_INSTALL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/cmake/${PROJECT_NAME}Config.cmake)")
+
+# install(DIRECTORY lib
+#   DESTINATION ${EUSDIR}/lib
+#   FILES_MATCHING PATTERN "*.l" PATTERN ".svn" EXCLUDE
+# )
+
+# install(DIRECTORY test
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+#   USE_SOURCE_PERMISSIONS
+#   )


### PR DESCRIPTION
see `eus_nlopt catkinize #38`

separate CMakeLists.txt into catkin.cmake & CMakeLists.txt, and in catkin.cmake, add catkin_package declaration for generating config.cmake file.
