### PR TITLE
do not subscribe if no need to publish message

### DIFF
--- a/jsk_topic_tools/include/jsk_topic_tools/relay_nodelet.h
+++ b/jsk_topic_tools/include/jsk_topic_tools/relay_nodelet.h
@@ -38,6 +38,8 @@
 
 #include <nodelet/nodelet.h>
 #include <topic_tools/shape_shifter.h>
+#include <boost/thread.hpp>
+#include <boost/thread/mutex.hpp>
 
 namespace jsk_topic_tools
 {
@@ -48,9 +50,13 @@ namespace jsk_topic_tools
     virtual void onInit();
     virtual void inputCallback(const boost::shared_ptr<topic_tools::ShapeShifter const>& msg);
   protected:
+    virtual void connectCb();
+    virtual void disconnectCb();
+    boost::mutex mutex_;
     ros::Publisher pub_;
     ros::Subscriber sub_;
     bool advertised_;
+    bool subscribing_;
     ros::NodeHandle pnh_;
     ros::TransportHints th_;
   };

--- a/jsk_topic_tools/src/relay_nodelet.cpp
+++ b/jsk_topic_tools/src/relay_nodelet.cpp
@@ -47,12 +47,61 @@ namespace jsk_topic_tools
   
   void Relay::inputCallback(const boost::shared_ptr<topic_tools::ShapeShifter const>& msg)
   {
+    boost::mutex::scoped_lock(mutex_);
     if (!advertised_) {
-      pub_ = msg->advertise(pnh_, "output", 1);
+      // this block is called only once
+      // in order to advertise topic.
+      // we need to subscribe at least one message
+      // in order to detect message definition.
+      ros::SubscriberStatusCallback connect_cb
+        = boost::bind( &Relay::connectCb, this);
+      ros::SubscriberStatusCallback disconnect_cb
+        = boost::bind( &Relay::disconnectCb, this);
+      ros::AdvertiseOptions opts("output", 1,
+                                 msg->getMD5Sum(),
+                                 msg->getDataType(),
+                                 msg->getMessageDefinition(),
+                                 connect_cb,
+                                 disconnect_cb);
+      opts.latch = false;
+      pub_ = pnh_.advertise(opts);
       advertised_ = true;
+      // shutdown subscriber
+      sub_.shutdown();
     }
-    if (pub_.getNumSubscribers() > 0) {
+    else if (pub_.getNumSubscribers() > 0) {
       pub_.publish(msg);
+    }
+  }
+
+  void Relay::connectCb()
+  {
+    boost::mutex::scoped_lock(mutex_);
+    NODELET_DEBUG("connectCB");
+    if (advertised_) {
+      if (pub_.getNumSubscribers() > 0) {
+        if (!subscribing_) {
+          NODELET_DEBUG("suscribe");
+          sub_ = pnh_.subscribe<topic_tools::ShapeShifter>("input", 1,
+                                                           &Relay::inputCallback, this, th_);
+          subscribing_ = true;
+        }
+      }
+    }
+  }
+
+  void Relay::disconnectCb()
+  {
+    boost::mutex::scoped_lock(mutex_);
+    NODELET_DEBUG("disconnectCb");
+    if (advertised_) {
+      if (pub_.getNumSubscribers() == 0) {
+        if (subscribing_) {
+          NODELET_DEBUG("disconnect");
+          sub_.shutdown();
+          subscribing_ = false;
+        }
+      }
     }
   }
   


### PR DESCRIPTION
do not subscribe if no need to publish message.
1. subscribe input
2. advertise output according to the input message
3. unsubscribe input
4. check the number of subscribers of the output and if the number is greater equal than 1,
   subscribe ~input again and relay the message
