### PR TITLE
Fix python twitter

### DIFF
--- a/3rdparty/python_twitter/Makefile
+++ b/3rdparty/python_twitter/Makefile
@@ -3,6 +3,7 @@ all: installed
 TOP_DIR = $(shell pwd)
 GIT_DIR = build/python-twitter
 GIT_URL = https://github.com/bear/python-twitter
+GIT_REVISION = v0.8.5
 include $(shell rospack find mk)/git_checkout.mk
 
 installed: $(GIT_DIR) patched
@@ -17,7 +18,7 @@ installed: $(GIT_DIR) patched
 	touch installed
 
 clean:
-	rm -rf installed bin lib src
+	rm -rf installed bin lib src build
 
 wipe: clean
 	rm -rf $(GIT_DIR)


### PR DESCRIPTION
specify the version of python twitter (v0.8.5).

In order to avoid the following error:

```
HEAD is now at 07debf9 Merge pull request #168 from mafagafo/master
mkdir -p src; mkdir -p bin
mkdir -p /home/travis/build/jsk-ros-pkg/jsk_common/3rdparty/python_twitter/build/lib/python2.7/site-packages/
cd build/python-twitter && pip install --user -r requirements.txt
Could not open requirements file: [Errno 2] No such file or directory: 'requirements.txt'
Storing debug log for failure in /home/travis/.pip/pip.log
make: *** [installed] Error 1
```
