### PR TITLE
Add vital checker from jsk pcl ros

### DIFF
--- a/jsk_topic_tools/CMakeLists.txt
+++ b/jsk_topic_tools/CMakeLists.txt
@@ -59,6 +59,7 @@ jsk_topic_tools_nodelet(src/hz_measure_nodelet.cpp
 
 rosbuild_add_library (jsk_topic_tools
   ${jsk_topic_tools_nodelet_sources}
+  src/vital_checker.cpp
   src/time_accumulator.cpp)
 
 #target_link_libraries(example ${PROJECT_NAME})

--- a/jsk_topic_tools/catkin.cmake
+++ b/jsk_topic_tools/catkin.cmake
@@ -52,7 +52,8 @@ jsk_topic_tools_nodelet(src/hz_measure_nodelet.cpp
 
 add_library(jsk_topic_tools SHARED
   ${jsk_topic_tools_nodelet_sources}
-  src/time_accumulator.cpp)
+  src/time_accumulator.cpp
+  src/vital_checker.cpp)
   
 target_link_libraries(jsk_topic_tools ${catkin_LIBRARIES})
 

--- a/jsk_topic_tools/include/jsk_topic_tools/vital_checker.h
+++ b/jsk_topic_tools/include/jsk_topic_tools/vital_checker.h
@@ -1,0 +1,70 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#ifndef JSK_TOPIC_TOOLS_VITAL_CHECKER_H_
+#define JSK_TOPIC_TOOLS_VITAL_CHECKER_H_
+
+#include <ros/time.h>
+#include <boost/accumulators/accumulators.hpp>
+#include <boost/accumulators/statistics/stats.hpp>
+#include <boost/accumulators/statistics/min.hpp>
+#include <boost/accumulators/statistics/max.hpp>
+#include <boost/accumulators/statistics/variance.hpp>
+
+#include <boost/timer.hpp>
+
+#include <boost/thread.hpp>
+
+namespace jsk_topic_tools
+{
+  // multi-thread safe
+  class VitalChecker
+  {
+  public:
+    typedef boost::shared_ptr<VitalChecker> Ptr;
+    VitalChecker(const double dead_sec);
+    virtual ~VitalChecker();
+    void poke();
+    bool isAlive();
+    double deadSec();
+  protected:
+    ros::Time last_alive_time_;
+    double dead_sec_;
+    boost::mutex mutex_;
+  private:
+  };
+}
+
+#endif

--- a/jsk_topic_tools/src/vital_checker.cpp
+++ b/jsk_topic_tools/src/vital_checker.cpp
@@ -1,0 +1,72 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include "jsk_topic_tools/vital_checker.h"
+
+namespace jsk_topic_tools
+{
+  VitalChecker::VitalChecker(const double dead_sec):
+    dead_sec_(dead_sec)
+  {
+
+  }
+
+  VitalChecker::~VitalChecker()
+  {
+
+  }
+
+  void VitalChecker::poke()
+  {
+    boost::mutex::scoped_lock lock(mutex_);
+    last_alive_time_ = ros::Time::now();
+  }
+
+  bool VitalChecker::isAlive()
+  {
+    bool ret;
+    {
+     boost::mutex::scoped_lock lock(mutex_);
+     ret = (ros::Time::now() - last_alive_time_).toSec() < dead_sec_;
+    }
+    return ret;
+  }
+
+  double VitalChecker::deadSec()
+  {
+    return dead_sec_;
+  }
+
+}


### PR DESCRIPTION
`VitalChecker` is a utility class to check the node is alive or not. 
the class is originally implemented in jsk_pcl_ros.
