### PR TITLE
add save_all_image arg to hrp2_record.launch

### DIFF
--- a/jsk_data/launch/hrp2_record.launch
+++ b/jsk_data/launch/hrp2_record.launch
@@ -4,7 +4,7 @@
   <arg name="camera_namespace" default="camera" />
   <arg name="save_openni" default="true" />
   <arg name="save_robot_model" default="true" />
-  <arg name="save_all_image" default="true" />
+  <arg name="save_all_image" default="false" />
   <arg name="other_topics" default=""/>
 
   <include file="$(find jsk_data)/launch/common_record.launch">


### PR DESCRIPTION
Add argument save_all_image to hrp2_record.launch.
Sometimes recording image topic makes communication slow (in hrp2016), so we need option to disable image topic.
Default is true, so it works in the same way in default.
