### PR TITLE
Rename executable of multi_map_server to avoid conflict against map_server

### DIFF
--- a/jsk_ros_patch/multi_map_server/catkin.cmake
+++ b/jsk_ros_patch/multi_map_server/catkin.cmake
@@ -31,10 +31,10 @@ catkin_package(
 )
 
 link_directories(${map_server_PREFIX}/lib)
-add_executable(map_server src/main.cpp)
-target_link_libraries(map_server ${catkin_LIBRARIES} image_loader SDL SDL_image yaml-cpp)
+add_executable(multi_map_server src/main.cpp)
+target_link_libraries(multi_map_server ${catkin_LIBRARIES} image_loader SDL SDL_image yaml-cpp)
 
-install(TARGETS map_server
+install(TARGETS multi_map_server
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}


### PR DESCRIPTION
If we compile multi_map_server with map_server in the same catkin workspace, target of map_server would conflict.

So use change the output name of executable to multi_map_server
