### PR TITLE
add oauth2 and oauthlib to depends, Fixes #531

### DIFF
--- a/rostwitter/package.xml
+++ b/rostwitter/package.xml
@@ -16,10 +16,14 @@
   <build_depend>python-setuptools</build_depend>
   <build_depend>mk</build_depend>
   <build_depend>git</build_depend>
+  <build_depend>python-oauth2</build_depend>
+  <build_depend>python-oauthlib</build_depend>
 
   <run_depend>rospy</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>python-simplejson</run_depend>
+  <run_depend>python-oauth2</run_depend>
+  <run_depend>python-oauthlib</run_depend>
 
 
   <export>


### PR DESCRIPTION
once https://github.com/ros/rosdistro/pull/5824 is merged, you can use this workaround.
but I'm not sure what happens for deb package, for example if we install rostwitter by
apt-get ros-hydro-rostwitter, it may not run pip install oauthlib. So do I have to run 
that by manually?
