### PR TITLE
Allow failure of indigo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
     - env: ROS_DISTRO=groovy ROSWS=wstool BUILDER=catkin    USE_DEB=true
     - env: ROS_DISTRO=groovy ROSWS=wstool BUILDER=catkin    USE_DEB=false
     - env: ROS_DISTRO=hydro  ROSWS=wstool BUILDER=catkin    USE_DEB=false
+    - env: ROS_DISTRO=indigo  ROSWS=wstool BUILDER=catkin   USE_DEB=true
     - env: ROS_DISTRO=indigo  ROSWS=wstool BUILDER=catkin   USE_DEB=false
 script: source .travis/travis.sh
 before_script:


### PR DESCRIPTION
temporal patch.

Please re-enable indigo testing after resolving the problems like

```
+ git clone http://github.com/jsk-ros-pkg/jsk_common jenkins-trusty-travis-4596/jsk-ros-pkg/jsk_common
Cloning into 'jenkins-trusty-travis-4596/jsk-ros-pkg/jsk_common'...
+ cd jenkins-trusty-travis-4596/jsk-ros-pkg/jsk_common
+ git fetch -q origin +refs/pull/*:refs/remotes/pull/*
+ git checkout -qf f4e423564e7c87b557585fc8683cf6a237a70130
fatal: reference is not a tree: f4e423564e7c87b557585fc8683cf6a237a70130
```

```
http://jenkins.jsk.imi.i.u-tokyo.ac.jp:8080/job/trusty-travis/build ROS_DISTRO=indigo&TRAVIS_BRANCH=master&BUILDER=catkin&ROSWS=wstool&TRAVIS_REPO_SLUG=jsk-ros-pkg%2Fjsk_common&TRAVIS_COMMIT=f4e423564e7c87b557585fc8683cf6a237a70130&USE_DEB=true
Traceback (most recent call last):
  File "./.travis/travis_jenkins.py", line 82, in <module>
    info = j.get_build_info('trusty-travis',next_build_number)
  File "./.travis/travis_jenkins.py", line 64, in get_build_info
    % (name, number))
jenkins.JenkinsException: job[trusty-travis] number[4603] does not exist
+++exit 1
```
