### PR TITLE
Revert "Allow failure of indigo"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ matrix:
     - env: ROS_DISTRO=groovy ROSWS=wstool BUILDER=catkin    USE_DEB=true
     - env: ROS_DISTRO=groovy ROSWS=wstool BUILDER=catkin    USE_DEB=false
     - env: ROS_DISTRO=hydro  ROSWS=wstool BUILDER=catkin    USE_DEB=false
-    - env: ROS_DISTRO=indigo  ROSWS=wstool BUILDER=catkin   USE_DEB=true
     - env: ROS_DISTRO=indigo  ROSWS=wstool BUILDER=catkin   USE_DEB=false
 script: source .travis/travis.sh
 before_script:


### PR DESCRIPTION
Reverts jsk-ros-pkg/jsk_common#562

this is not problem of travis.yml nor travis soft, but jenkins did not hold enough backup
