### PR TITLE
fix prompt when rossetlocal is called

### DIFF
--- a/jsk_tools/src/bashrc.ros
+++ b/jsk_tools/src/bashrc.ros
@@ -12,8 +12,10 @@ function rossetrobot() { # 自分のよく使うロボットのhostnameを入れ
 }
 
 function rossetlocal() {
-    export ROS_MASTER_URI=http://localhost:11311
-    echo -e "\e[1;31mset ROS_MASTER_URI to $ROS_MASTER_URI\e[m"
+    rossetrobot localhost
+    if [[ "${PS1}" =~ \[http://.*:.*\]\ (.*)$ ]] ; then
+        export PS1="${BASH_REMATCH[1]}"
+    fi
 }
 
 function rossetip_dev() {


### PR DESCRIPTION
現状は`rossetrobot hrp2` でプロンプトが変わった後に， `rossetlocal` をしてもプロンプトがhrp2のままになってしまいますが，
このPRで `rossetlocal` をするとプロンプトが無印に戻ります．
