### PR TITLE
rename rossetrobot -> rossetmaster

### DIFF
--- a/jsk_tools/src/bashrc.ros
+++ b/jsk_tools/src/bashrc.ros
@@ -1,6 +1,6 @@
 # -*- mode: Shell-script; -*-
 
-function rossetrobot() { # 自分のよく使うロボットのhostnameを入れる
+function rossetmaster() { # 自分のよく使うロボットのhostnameを入れる
     local hostname=${1-"pr1040"}
     local ros_port=${2-"11311"}
     export ROS_MASTER_URI=http://$hostname:$ros_port
@@ -10,6 +10,7 @@ function rossetrobot() { # 自分のよく使うロボットのhostnameを入れ
     export PS1="\[\033[00;31m\][$ROS_MASTER_URI]\[\033[00m\] ${PS1}"
     echo -e "\e[1;31mset ROS_MASTER_URI to $ROS_MASTER_URI\e[m"
 }
+alias rossetrobot=rossetmaster
 
 function rossetlocal() {
     export ROS_MASTER_URI=http://localhost:11311


### PR DESCRIPTION
- rename rosetmaster, because this is mainly used to set ros master and you can set to localhost, which is not robot
- keep rossetrobot for backword compatibility
