### PR TITLE
add patch for removing old gazebo settings

### DIFF
--- a/jsk_ros_patch/collada_urdf_jsk_patch/Makefile
+++ b/jsk_ros_patch/collada_urdf_jsk_patch/Makefile
@@ -5,7 +5,7 @@ GIT_DIR = build/robot_model/src
 GIT_URL = git://github.com/ros/robot_model.git
 GIT_REVISION = ${SOURCE_DISTRO}-devel
 PATCH_DIR = $(CURDIR)
-GIT_PATCH = ${PATCH_DIR}/use_assimp_devel.patch
+GIT_PATCH = ${PATCH_DIR}/use_assimp_devel.patch ${PATCH_DIR}/collada_urdf_latest_gazebo.patch
 BUILD_BIN_DIR  = build/robot_model/devel/lib/collada_urdf
 include $(shell rospack find mk)/git_checkout.mk
 

--- a/jsk_ros_patch/collada_urdf_jsk_patch/collada_urdf_latest_gazebo.patch
+++ b/jsk_ros_patch/collada_urdf_jsk_patch/collada_urdf_latest_gazebo.patch
@@ -1,0 +1,24 @@
+diff --git a/collada_urdf/src/collada_to_urdf.cpp b/collada_urdf/src/collada_to_urdf.cpp
+index 3a4d6e6..982f3bf 100644
+--- a/collada_urdf/src/collada_to_urdf.cpp
++++ b/collada_urdf/src/collada_to_urdf.cpp
+@@ -508,6 +508,7 @@ void printTreeXML(boost::shared_ptr<const Link> link, string name, string file)
+   os << "<?xml version=\"1.0\"?>" << endl;
+   os << "<robot name=\"" << name << "\"" << endl;
+   os << "       xmlns:xi=\"http://www.w3.org/2001/XInclude\"" << endl;
++#if GAZEBO_1_0 // old style, do not match gazebo 4.1
+   os << "       xmlns:gazebo=\"http://playerstage.sourceforge.net/gazebo/xmlschema/#gz\"" << endl;
+   os << "       xmlns:model=\"http://playerstage.sourceforge.net/gazebo/xmlschema/#model\"" << endl;
+   os << "       xmlns:sensor=\"http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor\"" << endl;
+@@ -518,8 +519,9 @@ void printTreeXML(boost::shared_ptr<const Link> link, string name, string file)
+   os << "       xmlns:rendering=\"http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering\"" << endl;
+   os << "       xmlns:renderable=\"http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable\"" << endl;
+   os << "       xmlns:controller=\"http://playerstage.sourceforge.net/gazebo/xmlschema/#controller\"" << endl;
+-  os << "       xmlns:physics=\"http://playerstage.sourceforge.net/gazebo/xmlschema/#physics\">" << endl;
+-
++  os << "       xmlns:physics=\"http://playerstage.sourceforge.net/gazebo/xmlschema/#physics\"" << endl;
++#endif
++  os << "       >" << endl;
+   addChildLinkNamesXML(link, os);
+ 
+   addChildJointNamesXML(link, os);


### PR DESCRIPTION
This is the same patch as
https://github.com/ros/robot_model/pull/95
https://github.com/ros/robot_model/pull/96
This should be removed after these PR merged
