### PR TITLE
add upstart scripts

### DIFF
--- a/jsk_tools/scripts/upstart/robots/hrp2/roscore.conf
+++ b/jsk_tools/scripts/upstart/robots/hrp2/roscore.conf
@@ -1,0 +1,18 @@
+description "roscore daemon"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+umask 022
+
+script
+     . /opt/ros/hydro/setup.sh
+     MASTER_HOST=`grep rosset /home/hrpuser/.bashrc | grep -v \# | grep -v function | grep -v rossetip | grep -v rossetrobot | sed s/rosset//g`
+     ROSCORE_PORT=`echo $MASTER_HOST | sed s/hrp2/10/g`
+     export ROS_MASTER_URI="http://${MASTER_HOST}v:${ROSCORE_PORT}"
+     roscore -p ${ROSCORE_PORT}
+end script
+
+post-stop script
+     . /opt/ros/hydro/setup.sh
+     rosclean purge -y          #not ~/.ros but /root/.ros
+end script

--- a/jsk_tools/scripts/upstart/robots/sample/README.md
+++ b/jsk_tools/scripts/upstart/robots/sample/README.md
@@ -1,0 +1,13 @@
+## example
+
+1. ``roscd jsk_tools/scripts/upstart/robots/sample``
+1. ``find *.conf | xargs sed -i "s/eisoku/$USER/g" *.conf``
+1. ``rosrun jsk_tools setup_upstart_jobs.bash sample install``
+1. ``sudo reboot``
+
+## check
+1. ``byobu``
+
+Open a new terminal
+1. ``sudo initctl stop test1``
+1. ``sudo initctl start test1``

--- a/jsk_tools/scripts/upstart/robots/sample/roscore.conf
+++ b/jsk_tools/scripts/upstart/robots/sample/roscore.conf
@@ -1,0 +1,15 @@
+description "roscore daemon"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+umask 022
+
+script
+     . /opt/ros/hydro/setup.sh
+     roscore
+end script
+
+post-stop script
+     . /opt/ros/hydro/setup.sh
+     rosclean purge -y          # not ~/.ros but /root/.ros
+end script

--- a/jsk_tools/scripts/upstart/robots/sample/start-terminal-multiplexer.conf
+++ b/jsk_tools/scripts/upstart/robots/sample/start-terminal-multiplexer.conf
@@ -1,0 +1,10 @@
+description "terminal multiplexer daemon"
+
+start on started screen-cleanup
+stop on runlevel [!2345]
+umask 022
+
+script
+     sudo -iu eisoku /bin/bash -i -c 'source `rospack find jsk_tools`/scripts/upstart/terminal-multiplexer-utils.bash && create-session' &
+     while :; do sleep 86400; done
+end script

--- a/jsk_tools/scripts/upstart/robots/sample/test1.conf
+++ b/jsk_tools/scripts/upstart/robots/sample/test1.conf
@@ -1,0 +1,18 @@
+description "test 1 daemon"
+
+start on started start-terminal-multiplexer
+stop on stopped start-terminal-multiplexer
+umask 022
+
+pre-start script
+     /bin/sleep 1
+end script
+
+script
+     sudo -iu eisoku /bin/bash -i -c 'source `rospack find jsk_tools`/scripts/upstart/terminal-multiplexer-utils.bash && new-window first "echo \"Hello World\!\""' &
+     while :; do sleep 86400; done
+end script
+
+pre-stop script
+     sudo -iu eisoku /bin/bash -i -c 'source `rospack find jsk_tools`/scripts/upstart/terminal-multiplexer-utils.bash && kill-window first'
+end script

--- a/jsk_tools/scripts/upstart/robots/sample/test2.conf
+++ b/jsk_tools/scripts/upstart/robots/sample/test2.conf
@@ -1,0 +1,18 @@
+description "test 2 daemon"
+
+start on started test1
+stop on stopped start-terminal-multiplexer
+umask 022
+
+pre-start script
+     /bin/sleep 1
+end script
+
+script
+     sudo -iu eisoku /bin/bash -i -c 'source `rospack find jsk_tools`/scripts/upstart/terminal-multiplexer-utils.bash && new-window second "htop"' &
+     while :; do sleep 86400; done
+end script
+
+pre-stop script
+     sudo -iu eisoku /bin/bash -i -c 'source `rospack find jsk_tools`/scripts/upstart/terminal-multiplexer-utils.bash && kill-window second'
+end script

--- a/jsk_tools/scripts/upstart/robots/sample/test3.conf
+++ b/jsk_tools/scripts/upstart/robots/sample/test3.conf
@@ -1,0 +1,18 @@
+description "test 3 daemon"
+
+start on started test2
+stop on stopped start-terminal-multiplexer
+umask 022
+
+pre-start script
+     /bin/sleep 1
+end script
+
+script
+     sudo -iu eisoku /bin/bash -i -c 'source `rospack find jsk_tools`/scripts/upstart/terminal-multiplexer-utils.bash && new-window third "env"' &
+     while :; do sleep 86400; done
+end script
+
+pre-stop script
+     sudo -iu eisoku /bin/bash -i -c 'source `rospack find jsk_tools`/scripts/upstart/terminal-multiplexer-utils.bash && kill-window third'
+end script

--- a/jsk_tools/scripts/upstart/robots/staro/hrpsys.conf
+++ b/jsk_tools/scripts/upstart/robots/staro/hrpsys.conf
@@ -1,0 +1,18 @@
+description "hrpsys daemon"
+
+start on (started monitor and started roscore)
+stop on (stopped start-terminal-multiplexer or stopped roscore)
+umask 022
+
+pre-start script
+     /bin/sleep 1
+end script
+
+script
+     sudo -iu leus /bin/bash -i -c 'source `rospack find jsk_tools`/scripts/upstart/terminal-multiplexer-utils.bash && new-window rtcd `rospack find staro_ros_bridge`/scripts/start-rtcd.sh' &
+     while :; do sleep 86400; done
+end script
+
+pre-stop script
+     sudo -iu leus /bin/bash -i -c 'source `rospack find jsk_tools`/scripts/upstart/terminal-multiplexer-utils.bash && kill-window rtcd'
+end script

--- a/jsk_tools/scripts/upstart/robots/staro/monitor.conf
+++ b/jsk_tools/scripts/upstart/robots/staro/monitor.conf
@@ -1,0 +1,18 @@
+description "status monitor daemon"
+
+start on started servo
+stop on (stopped servo or stopped start-terminal-multiplexer)
+umask 022
+
+pre-start script
+     /bin/sleep 1
+end script
+
+script
+     sudo -iu leus /bin/bash -i -c 'source `rospack find jsk_tools`/scripts/upstart/terminal-multiplexer-utils.bash && new-window monitor `rospack find trans_vm`/bin/status_monitor' &
+     while :; do sleep 86400; done
+end script
+
+pre-stop script
+     sudo -iu leus /bin/bash -i -c 'source `rospack find jsk_tools`/scripts/upstart/terminal-multiplexer-utils.bash && kill-window monitor'
+end script

--- a/jsk_tools/scripts/upstart/robots/staro/navchip.conf
+++ b/jsk_tools/scripts/upstart/robots/staro/navchip.conf
@@ -1,0 +1,18 @@
+description "navchip shm daemon"
+
+start on started start-terminal-multiplexer
+stop on stopped start-terminal-multiplexer
+umask 022
+
+pre-start script
+     /bin/sleep 1
+end script
+
+script
+     sudo -iu leus /bin/bash -i -c 'source `rospack find jsk_tools`/scripts/upstart/terminal-multiplexer-utils.bash && new-window navchip `rospack find trans_vm`/navchip/navchip_shm' &
+     while :; do sleep 86400; done
+end script
+
+pre-stop script
+     sudo -iu leus /bin/bash -i -c 'source `rospack find jsk_tools`/scripts/upstart/terminal-multiplexer-utils.bash && kill-window navchip'
+end script

--- a/jsk_tools/scripts/upstart/robots/staro/nitta.conf
+++ b/jsk_tools/scripts/upstart/robots/staro/nitta.conf
@@ -1,0 +1,18 @@
+description "nitta shm daemon"
+
+start on started navchip
+stop on stopped start-terminal-multiplexer
+umask 022
+
+pre-start script
+     /bin/sleep 1
+end script
+
+script
+     sudo -iu leus /bin/bash -i -c 'source `rospack find jsk_tools`/scripts/upstart/terminal-multiplexer-utils.bash && new-window nitta `rospack find trans_vm`/nitta/nitta_shm' &
+     while :; do sleep 86400; done
+end script
+
+pre-stop script
+     sudo -iu leus /bin/bash -i -c 'source `rospack find jsk_tools`/scripts/upstart/terminal-multiplexer-utils.bash && kill-window nitta'
+end script

--- a/jsk_tools/scripts/upstart/robots/staro/robotiq.conf
+++ b/jsk_tools/scripts/upstart/robots/staro/robotiq.conf
@@ -1,0 +1,10 @@
+description "robotiq hand daemon"
+
+start on started roscore
+stop on stopped roscore
+umask 022
+
+script
+     sudo -iu leus /bin/bash -i -c 'source ~/.bashrc && python `rospack find staro_ros_bridge`/scripts/executeRobotiqHandTcp.py leftRobotiqSModel 10.68.0.21 leftSModelRobotInput leftSModelRobotOutput' &
+     sudo -iu leus /bin/bash -i -c 'source ~/.bashrc && python `rospack find staro_ros_bridge`/scripts/executeRobotiqHandTcp.py rightRobotiqSModel 10.68.0.22 rightSModelRobotInput rightSModelRobotOutput'
+end script

--- a/jsk_tools/scripts/upstart/robots/staro/ros-bridge.conf
+++ b/jsk_tools/scripts/upstart/robots/staro/ros-bridge.conf
@@ -1,0 +1,18 @@
+description "ros bridge daemon"
+
+start on (started hrpsys and started roscore)
+stop on (stopped start-terminal-multiplexer or stopped roscore)
+umask 022
+
+pre-start script
+     /bin/sleep 1
+end script
+
+script
+     sudo -iu leus /bin/bash -i -c 'source `rospack find jsk_tools`/scripts/upstart/terminal-multiplexer-utils.bash && new-window ros-bridge `rospack find staro_ros_bridge`/scripts/start-ros-bridge.sh' &
+     while :; do sleep 86400; done
+end script
+
+pre-stop script
+     sudo -iu leus /bin/bash -i -c 'source `rospack find jsk_tools`/scripts/upstart/terminal-multiplexer-utils.bash && kill-window ros-bridge'
+end script

--- a/jsk_tools/scripts/upstart/robots/staro/roscore.conf
+++ b/jsk_tools/scripts/upstart/robots/staro/roscore.conf
@@ -1,0 +1,10 @@
+description "roscore daemon"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+umask 022
+
+script
+     . /opt/ros/hydro/setup.sh
+     roscore
+end script

--- a/jsk_tools/scripts/upstart/robots/staro/servo.conf
+++ b/jsk_tools/scripts/upstart/robots/staro/servo.conf
@@ -1,0 +1,18 @@
+description "simple shm daemon"
+
+start on started nitta
+stop on stopped start-terminal-multiplexer
+umask 022
+
+pre-start script
+     /bin/sleep 1
+end script
+
+script
+     sudo -iu leus /bin/bash -i -c "source \`rospack find jsk_tools\`/scripts/upstart/terminal-multiplexer-utils.bash && new-window servo \`rospack find staro_ros_bridge\`/scripts/run_servo.sh" &
+     while :; do sleep 86400; done
+end script
+
+pre-stop script
+     sudo -iu leus /bin/bash -i -c "source \`rospack find jsk_tools\`/scripts/upstart/terminal-multiplexer-utils.bash && kill-window servo"
+end script

--- a/jsk_tools/scripts/upstart/robots/staro/start-terminal-multiplexer.conf
+++ b/jsk_tools/scripts/upstart/robots/staro/start-terminal-multiplexer.conf
@@ -1,0 +1,10 @@
+description "terminal multiplexer daemon"
+
+start on started screen-cleanup
+stop on runlevel [!2345]
+umask 022
+
+script
+     sudo -iu leus /bin/bash -i -c 'source `rospack find jsk_tools`/scripts/upstart/terminal-multiplexer-utils.bash && create-session' &
+     while :; do sleep 86400; done
+end script

--- a/jsk_tools/scripts/upstart/setup_upstart_jobs.bash
+++ b/jsk_tools/scripts/upstart/setup_upstart_jobs.bash
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Condition check
+if [ $# -ne 2 ]; then
+    echo "USAGE : rosrun jsk_tools setup_upstart_jobs.bash staro install (and reboot)"
+    echo "USAGE : rosrun jsk_tools setup_upstart_jobs.bash hrp2 uninstall (and reboot)"
+    exit 1
+elif [ ! -e `rospack find jsk_tools`/scripts/upstart/robots/$1 ]; then
+    echo "No such directory : "$1
+    exit 1
+fi
+
+
+# install or uninstall
+if [ $2 = "install" ]; then
+    for j in `rospack find jsk_tools`/scripts/upstart/robots/$1/*.conf
+    do
+        sudo cp -f $j /etc/init/ # upstart does not support symbolic links
+        echo "sudo cp -f "$j" /etc/init"
+    done
+elif [ $2 = "uninstall" ]; then
+    for j in `rospack find jsk_tools`/scripts/upstart/robots/$1/*.conf
+    do
+        sudo rm -f /etc/init/${j##*/}
+        echo "sudo rm -f /etc/init/"${j##*/}
+    done
+fi

--- a/jsk_tools/scripts/upstart/terminal-multiplexer-utils.bash
+++ b/jsk_tools/scripts/upstart/terminal-multiplexer-utils.bash
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+SESSION_NAME=`hostname`
+DEFAULT_NAME=orig
+BACKEND=byobu-screen
+
+if [ `echo $BACKEND | grep 'tmux'` ]; then
+    function create-session() {
+        $BACKEND new-session -d -s $SESSION_NAME -n $DEFAULT_NAME
+        $BACKEND set-option prefix C-t
+        # $BACKEND set-window-option aggressive-resize on
+        $BACKEND set-option mouse-select-window on
+        $BACKEND set-window-option -g mode-mouse copy-mode
+    }
+    function new-window() {
+        $BACKEND new-window -k -n $1 -t $SESSION_NAME
+        $BACKEND send-keys -t $SESSION_NAME:$1 "${@:2}" C-m # how to pass whtie space ?
+        $BACKEND select-window -t 0
+    }
+    function kill-window() {
+        $BACKEND kill-window -t $SESSION_NAME:$1
+    }
+elif [ `echo $BACKEND | grep 'screen'` ]; then
+    function create-session() {
+        $BACKEND -S $SESSION_NAME -d -m
+        $BACKEND -S $SESSION_NAME -p 0 -X title $DEFAULT_NAME
+    }
+    function new-window() {
+        $BACKEND -S $SESSION_NAME -X screen -t $1
+        $BACKEND -S $SESSION_NAME -p $1 -X stuff "${@:2}$(printf \\r)"
+    }
+    function kill-window() {
+        $BACKEND -S $SESSION_NAME -p $1 -X kill
+        sleep 2                 # wait to kill
+    }
+fi


### PR DESCRIPTION
「restart roscore automatically when rebooting machines」で言われていた件，やってみました．

> HRP２でもつかえるもの，ということで，rtmrosのどこかに移動させましょう．
こうやって，どんどんやっていることが一般的，汎用的，なっていっていいですね．

> jsk_commonか悩む所ではありますが、どっちでもいいと思います。

17号機のvの方は ``rosrun jsk_tools install.bash hrp2 install`` でroscoreを上げるやつをupstartに変えておきました．

上げ直したい場合はvにログインして，

```
sudo initctl stop roscore
sudo initctl start roscore
```

で出来ます．

``rosrun jsk_tools install.bash hrp2 uninstall`` 

で消せます．

また，screenやtmuxの上で自動起動したい場合のサンプルを``jsk_tools/scripts/upstart/robots/sample/README.md``に置きました．