### PR TITLE
Add new script: static_transform_pose_stamped. 

### DIFF
--- a/jsk_topic_tools/catkin.cmake
+++ b/jsk_topic_tools/catkin.cmake
@@ -4,6 +4,8 @@ project(jsk_topic_tools)
 
 find_package(catkin REQUIRED COMPONENTS topic_tools message_generation roscpp rostest std_msgs
   nodelet tf
+  geometry_msgs
+  eigen_conversions
   topic_tools)
 
 add_message_files(
@@ -28,7 +30,11 @@ include_directories(include ${catkin_INCLUDE_DIRS})
 add_executable(topic_buffer_server src/topic_buffer_server.cpp)
 add_executable(topic_buffer_client src/topic_buffer_client.cpp)
 add_executable(transform_merger src/transform_merger.cpp)
+add_executable(static_transform_pose_stamped
+  src/static_transform_pose_stamped.cpp)
 target_link_libraries(transform_merger ${catkin_LIBRARIES})
+target_link_libraries(static_transform_pose_stamped ${catkin_LIBRARIES})
+add_dependencies(static_transform_pose_stamped ${PROJECT_NAME}_gencpp)
 add_dependencies(topic_buffer_server ${PROJECT_NAME}_gencpp)
 add_dependencies(topic_buffer_client ${PROJECT_NAME}_gencpp)
 target_link_libraries(topic_buffer_server ${catkin_LIBRARIES})

--- a/jsk_topic_tools/package.xml
+++ b/jsk_topic_tools/package.xml
@@ -28,6 +28,8 @@
   <build_depend>rosnode</build_depend>
   <build_depend>dynamic_tf_publisher</build_depend>
   <build_depend>tf</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>eigen_conversions</build_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>topic_tools</run_depend>
   <run_depend>message_runtime</run_depend>
@@ -39,6 +41,8 @@
   <run_depend>rosnode</run_depend>
   <run_depend>dynamic_tf_publisher</run_depend>
   <run_depend>tf</run_depend>
+  <run_depend>geometry_msgs</run_depend>
+  <run_depend>eigen_conversions</run_depend>
   <export>
     <nodelet plugin="${prefix}/jsk_topic_tools_nodelet.xml"/>
   </export>

--- a/jsk_topic_tools/src/static_transform_pose_stamped.cpp
+++ b/jsk_topic_tools/src/static_transform_pose_stamped.cpp
@@ -1,0 +1,129 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <ros/ros.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <eigen_conversions/eigen_msg.h>
+
+namespace jsk_topic_tools
+{
+  class PoseStampedTransformer
+  {
+  public:
+    typedef boost::shared_ptr<PoseStampedTransformer> Ptr;
+    PoseStampedTransformer(double x, double y, double z,
+                           double yaw, double pitch, double roll,
+                           std::string from_topic,
+                           std::string to_topic);
+    virtual ~PoseStampedTransformer();
+  protected:
+    void transform(const geometry_msgs::PoseStamped::ConstPtr& pose_msg);
+    ros::Subscriber sub_;
+    ros::Publisher pub_;
+    double x_;
+    double y_;
+    double z_;
+    double roll_;
+    double pitch_;
+    double yaw_;
+  private:
+    
+  };
+
+  PoseStampedTransformer::PoseStampedTransformer(
+    double x, double y, double z,
+    double yaw, double pitch, double roll,
+    std::string from_topic, std::string to_topic):
+    x_(x), y_(y), z_(z), yaw_(yaw), pitch_(pitch), roll_(roll)
+  {
+    ros::NodeHandle nh;
+    pub_ = nh.advertise<geometry_msgs::PoseStamped>(
+      to_topic, 1);
+    sub_ = nh.subscribe(from_topic, 1,
+                        &PoseStampedTransformer::transform, this);
+  }
+
+  PoseStampedTransformer::~PoseStampedTransformer()
+  {
+
+  }
+
+  void PoseStampedTransformer::transform(
+    const geometry_msgs::PoseStamped::ConstPtr& pose_msg)
+  {
+    Eigen::Affine3d input_transform;
+    tf::poseMsgToEigen(pose_msg->pose, input_transform);
+    Eigen::AngleAxisd roll_angle(roll_, Eigen::Vector3d::UnitZ());
+    Eigen::AngleAxisd yaw_angle(yaw_, Eigen::Vector3d::UnitY());
+    Eigen::AngleAxisd pitch_angle(pitch_, Eigen::Vector3d::UnitX());
+
+    Eigen::Affine3d transformation
+      = Eigen::Translation3d(x_, y_, z_) * roll_angle * yaw_angle * pitch_angle;
+    Eigen::Affine3d output_transform = input_transform * transformation;
+    geometry_msgs::PoseStamped output_pose_msg;
+    tf::poseEigenToMsg(output_transform, output_pose_msg.pose);
+    output_pose_msg.header = pose_msg->header;
+    pub_.publish(output_pose_msg);
+  }
+  
+}
+
+int usage(char** argv)
+{
+  std::cerr << "Usage:: " << argv[0]
+            << " x y z yaw pitch roll from_topic to_topic"
+            << std::endl;
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "static_transform_pose_stamped",
+            ros::init_options::AnonymousName);
+  // x y z yaw pitch roll
+  if (argc != 9) {
+    usage(argv);
+    exit(1);
+  }
+  // parse argument
+  jsk_topic_tools::PoseStampedTransformer p(::atof(argv[1]),
+                                            ::atof(argv[2]),
+                                            ::atof(argv[3]),
+                                            ::atof(argv[4]),
+                                            ::atof(argv[5]),
+                                            ::atof(argv[6]),
+                                            argv[7],
+                                            argv[8]);
+  ros::spin();
+}


### PR DESCRIPTION
Add new script: static_transform_pose_stamped. 
It looks like tf's satatic_transform_publisher but it re-publishes geometry_msgs/PoseStamped.

usage:

```
$ rosrun jsk_topic_tools static_transform_pose_stamped x y z yaw pitch roll from_topic to_topic
```

![selection_001](https://cloud.githubusercontent.com/assets/40454/5505416/28ef06e0-87d4-11e4-9db1-bfc9a74e8caa.png)
