### PR TITLE
[nlopt] Add LIBS='-stdc++' to avoid link error on saucy

### DIFF
--- a/3rdparty/nlopt/Makefile
+++ b/3rdparty/nlopt/Makefile
@@ -10,7 +10,7 @@ MK_DIR = $(shell rospack find mk)
 include $(MK_DIR)/download_unpack_build.mk
 
 installed: $(SOURCE_DIR)/unpacked
-	(cd $(SOURCE_DIR) && ./configure --enable-shared --with-cxx --prefix=$(DSTDIR) && make && make install)
+	(cd $(SOURCE_DIR) && ./configure --enable-shared --with-cxx --prefix=$(DSTDIR) LIBS='-lstdc++' && make && make install)
 	touch installed
 clean:
 	-rm -rf include lib share $(SOURCE_DIR) installed


### PR DESCRIPTION
fix for https://github.com/jsk-ros-pkg/jsk_common/issues/666