### PR TITLE
downward: Use native bitwidth when compiling

### DIFF
--- a/3rdparty/downward/Makefile
+++ b/3rdparty/downward/Makefile
@@ -9,7 +9,7 @@ UNPACK_CMD=tar xvzf
 include $(shell rospack find mk)/download_unpack_build.mk
 
 installed: $(SOURCE_DIR)/unpacked
-	cd $(SOURCE_DIR)/src && ./build_all
+	cd $(SOURCE_DIR)/src && ./build_all DOWNWARD_BITWIDTH=native
 	touch installed
 
 clean:


### PR DESCRIPTION
Is there a reason that "downward" always compiles 32-bit binaries, even on 64-bit processors? This is a problem for ARM processors, becuase the `-m32` flag isn't valid, and so the compilation fails [1].

If there is no particular reason for 32-bit binaries on 64-bit processors, `DOWNWARD_BITWIDTH=native` should be used to allow the system to decide the appropriate bitwidth.

Once the new behavior is verified, the dependency on `g++-multilib` can be removed.

[1] https://csc.mcs.sdsmt.edu/jenkins/job/ros-indigo-downward_binaryrpm_21_armhfp/10/consoleFull