### PR TITLE
[jsk_network_tools] Add script to check size in lowspeed network

### DIFF
--- a/jsk_network_tools/scripts/silverhammer_lowspeed_check_size.py
+++ b/jsk_network_tools/scripts/silverhammer_lowspeed_check_size.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+import rospy
+import roslib
+import roslib.message
+import sys
+from roslib.message import get_message_class
+from jsk_network_tools.silverhammer_util import *
+from struct import calcsize
+def usage():
+    print "silverhammer_lowspeed_check_size.py message_packege/Message"
+
+def checkSize(class_str):
+    try:
+        message_class = get_message_class(class_str)
+        format = msgToStructFormat(message_class)
+        print class_str
+        print "  binary format: ", format
+        print "  size:               ", calcsize(format), "bytes"
+        print "                      ", 8 * calcsize(format), "bits"
+        print "  size w/ UDP header: ", calcsize(format) + 36, "bytes"
+        print "                      ", 8 * (calcsize(format) + 36), "bits"
+    except Exception, e:
+        print "cannot serialize %s" % class_str
+        print "  error: ", e.message
+        return
+
+    
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        usage()
+        sys.exit(1)
+    checkSize(sys.argv[1])


### PR DESCRIPTION
```
$ ./silverhammer_lowspeed_check_size.py jsk_network_tools/OCS2FC
jsk_network_tools/OCS2FC
  binary format:  !BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB??
  size:                34 bytes
                       272 bits
  size w/ UDP header:  70 bytes
                       560 bits
$ ./silverhammer_lowspeed_check_size.py jsk_network_tools/FC2OCS
jsk_network_tools/FC2OCS
  binary format:  !BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB?
  size:                57 bytes
                       456 bits
  size w/ UDP header:  93 bytes
                       744 bits
```