### PR TITLE
[jsk_tilt_laser] Add scan_to_cloud_chain to multisense.launch to get one-scan pointcloud.

### DIFF
--- a/jsk_tilt_laser/launch/multisense.launch
+++ b/jsk_tilt_laser/launch/multisense.launch
@@ -45,19 +45,18 @@
    <node pkg="dynamic_reconfigure" type="dynparam" name="set_multisense_spindle"
          args="set multisense motor_speed 1.57" />
 
-   <node name="tilt_scan_to_cloud"
+   <node name="tilt_scan_to_scan"
          pkg="laser_filters" type="scan_to_scan_filter_chain"
          output="screen">
      <remap from="scan" to="/multisense/lidar_scan" />
      <rosparam subst_value="true">
-#       target_frame: multisense/head_root
        scan_filter_chain:
        - name: shadows
          type: laser_filters/ScanShadowsFilter
          params:
            min_angle: 0
            max_angle: 170
-           neighbors: 10
+           neighbors: 5
            window: 1
        - name: dark_shadows
          type: LaserScanIntensityFilter
@@ -69,9 +68,19 @@
          type: laser_filters/LaserScanRangeFilter
          params:
            lower_threshold: 0.2 # 0.5
-           upper_threshold: .inf
+           upper_threshold: 30
      </rosparam>
      <remap from="scan_filtered" to="/multisense/lidar_scan_filtered" />
+   </node>
+   <node name="tilt_scan_to_cloud"
+         pkg="laser_filters" type="scan_to_cloud_filter_chain"
+         output="screen">
+     <remap from="scan" to="/multisense/lidar_scan_filtered" />
+     <rosparam>
+       target_frame: multisense/spindle
+       high_fidelity: true
+     </rosparam>
+     <remap from="cloud_filtered" to="/multisense/lidar_scan_cloud_filtered" />
    </node>
    <node pkg="nodelet" type="nodelet" name="multisense_laser_manager"
          args="manager" output="screen"/>


### PR DESCRIPTION
 We use ~high_fidelity=true in order to avoid
laser_geometry's bug to produce large sphere pointcloud

* sphere bug when we use ~high_fidelity=false

![sphere-bug](https://cloud.githubusercontent.com/assets/40454/5721156/59a07156-9b71-11e4-8da9-c1b648501f75.png)
