### PR TITLE
[jsk_network_tools] Add euslisp script to compress/decompres joint states

### DIFF
--- a/jsk_network_tools/CMakeLists.txt
+++ b/jsk_network_tools/CMakeLists.txt
@@ -6,6 +6,7 @@ catkin_python_setup()
 add_message_files(
   DIRECTORY msg
   FILES
+  CompressedAngleVectorPR2.msg
   Heartbeat.msg
   HeartbeatResponse.msg
   FC2OCS.msg

--- a/jsk_network_tools/euslisp/angle-vector-compress.l
+++ b/jsk_network_tools/euslisp/angle-vector-compress.l
@@ -1,0 +1,36 @@
+(defun compress-angle-vector (robot av &optional tms)
+  "Convert angle vector (float-vector) into uchar vector.
+   0 means equal to min-angle, and 255 means equal to max-angle."
+  (if tms
+      (error "time is not impremented!"))
+  (coerce (mapcar #'(lambda (v jt)
+                      (if (or (derivedp jt linear-joint)
+                              (not (infinite-joint-p jt)))
+                          (round (* (/ (- v (send jt :min-angle))
+                                       (- (send jt :max-angle)
+                                          (send jt :min-angle)))
+                                    255))
+                        (round (* (/ (abs (mod v 360)) 360.0) 255))))
+                  (coerce av cons) (send robot :joint-list))
+          integer-vector))
+
+
+(defun decompress-angle-vector (robot av)
+  "Decompress angle vector written in uchar vector to float-vector"
+  (coerce (mapcar #'(lambda (v jt)
+                      (if (or (derivedp jt linear-joint)
+                              (not (infinite-joint-p jt)))
+                          (+ (send jt :min-angle)
+                             (* (/ v 255.0)
+                                (- (send jt :max-angle)
+                                   (send jt :min-angle))))
+                        (* (/ v 255.0) 360.0)))
+                  (coerce av cons)
+                  (send robot :joint-list))
+          float-vector))
+
+(defun infinite-joint-p (jt)
+  (or (> (send jt :max-angle) 360)
+      (< (send jt :min-angle) -360)))
+
+(provide :compressed-angle-vector)

--- a/jsk_network_tools/euslisp/joint-state-compressor.l
+++ b/jsk_network_tools/euslisp/joint-state-compressor.l
@@ -1,0 +1,63 @@
+#!/usr/bin/env roseus
+(require :compressed-angle-vector "package://jsk_network_tools/euslisp/angle-vector-compress.l")
+(ros::roseus-add-msgs "sensor_msgs")
+
+(ros::roseus "joint_state_compressor")
+
+
+(setq *msg-type-string* (ros::get-param "~message_type"
+                          "jsk_network_tools/CompressedAngleVectorPR2"))
+(unless *msg-type-string*
+  (error "Please specify ~~message_type"))
+
+;; msg-type-string should be like "pkg_name/MessageType"
+;; euslisp string operation is poor, so we use pathname utilities to parse it
+(setq *message-package* (car (pathname-directory (pathname *msg-type-string*))))
+
+(ros::roseus-add-msgs *message-package*)
+
+(setq *message-type* (symbol-value
+                      (intern (string-upcase (send (pathname *msg-type-string*) :name))
+                              (string-upcase *message-package*))))
+;; load robot model
+
+(setq *robot-name* (ros::get-param "~robot" "pr2"))
+(unless *robot-name*
+  (error "Please specify ~~robot_name"))
+;; load robot files... it's not so good
+(setq *robot-model-files*
+      (list "package://pr2eus/pr2.l"
+            "package://hrpsys_ros_bridge_tutorials/models/hrp2jsk.l"
+            "package://hrpsys_ros_bridge_tutorials/models/hrp2jsknt.l"
+            "package://hrpsys_ros_bridge_tutorials/models/hrp2jsknts.l"
+            "package://hrpsys_ros_bridge_tutorials/models/staro.l"
+            "package://hrpsys_ros_bridge_tutorials/models/urataleg.l"
+            "package://hrpsys_ros_bridge_tutorials/models/samplerobot.l"
+            "package://hrpsys_ros_bridge_tutorials/models/hrp2w.l"))
+
+(dolist (f *robot-model-files*)
+  (if (probe-file (ros::resolve-ros-path f))
+      (load f)))
+
+(setq *robot* (make-robot-model-from-name *robot-name*))
+
+(defun joint-state-callback (inmsg)
+  (let ((msg (instance *message-type* :init))
+        (avs nil))
+    ;; update robot-model
+    (dolist (j (send *robot* :joint-list))
+      ;; lookup msg
+      (dotimes (i (length (send inmsg :name)))
+        (let ((n (elt (send inmsg :name) i)))
+          (if (string= n (send j :name))
+              (setq avs (append avs (list
+                                     (if (derivedp j linear-joint)
+                                         (* 1000 (elt (send inmsg :position) i))
+                                       (rad2deg (elt (send inmsg :position) i))))))))))
+    (send msg :angles (compress-angle-vector *robot* avs))
+    (ros::publish "/joint_states_compressed" msg)
+    ))
+(ros::advertise "/joint_states_compressed" *message-type*)
+(ros::subscribe "/joint_states" sensor_msgs::JointState #'joint-state-callback)
+
+(ros::spin)

--- a/jsk_network_tools/euslisp/joint-state-decompressor.l
+++ b/jsk_network_tools/euslisp/joint-state-decompressor.l
@@ -1,0 +1,62 @@
+#!/usr/bin/env roseus
+(require :compressed-angle-vector "package://jsk_network_tools/euslisp/angle-vector-compress.l")
+(ros::roseus-add-msgs "sensor_msgs")
+
+(ros::roseus "joint_state_decompressor")
+
+
+(setq *msg-type-string* (ros::get-param "~message_type"
+                          "jsk_network_tools/CompressedAngleVectorPR2"))
+(unless *msg-type-string*
+  (error "Please specify ~~message_type"))
+
+;; msg-type-string should be like "pkg_name/MessageType"
+;; euslisp string operation is poor, so we use pathname utilities to parse it
+(setq *message-package* (car (pathname-directory (pathname *msg-type-string*))))
+
+(ros::roseus-add-msgs *message-package*)
+
+(setq *message-type* (symbol-value
+                      (intern (string-upcase (send (pathname *msg-type-string*) :name))
+                              (string-upcase *message-package*))))
+;; load robot model
+
+(setq *robot-name* (ros::get-param "~robot" "pr2"))
+(unless *robot-name*
+  (error "Please specify ~~robot_name"))
+;; load robot files... it's not so good
+(setq *robot-model-files*
+      (list "package://pr2eus/pr2.l"
+            "package://hrpsys_ros_bridge_tutorials/models/hrp2jsk.l"
+            "package://hrpsys_ros_bridge_tutorials/models/hrp2jsknt.l"
+            "package://hrpsys_ros_bridge_tutorials/models/hrp2jsknts.l"
+            "package://hrpsys_ros_bridge_tutorials/models/staro.l"
+            "package://hrpsys_ros_bridge_tutorials/models/urataleg.l"
+            "package://hrpsys_ros_bridge_tutorials/models/samplerobot.l"
+            "package://hrpsys_ros_bridge_tutorials/models/hrp2w.l"))
+
+(dolist (f *robot-model-files*)
+  (if (probe-file (ros::resolve-ros-path f))
+      (load f)))
+
+(setq *robot* (make-robot-model-from-name *robot-name*))
+
+(defun joint-state-compressed-callback (inmsg)
+  (let ((msg (instance sensor_msgs::JointState :init)))
+    (send msg :name (send-all (send *robot* :joint-list) :name))
+    (let ((avs (coerce (decompress-angle-vector
+                        *robot* (send inmsg :angles))
+                       cons)))
+      (send msg :position (mapcar #'(lambda (v j)
+                                      (if (derivedp j linear-joint)
+                                          (* 0.001 v)
+                                        (deg2rad v)))
+                                  avs (send *robot* :joint-list))))
+    (send msg :header :stamp (ros::time-now))
+    (ros::publish "/joint_states_decompressed" msg)))
+
+(ros::advertise "/joint_states_decompressed" sensor_msgs::JointState)
+(ros::subscribe "/joint_states_compressed" *message-type*
+  #'joint-state-compressed-callback)
+
+(ros::spin)

--- a/jsk_network_tools/launch/joint_state_compress_sample.launch
+++ b/jsk_network_tools/launch/joint_state_compress_sample.launch
@@ -1,0 +1,17 @@
+<launch>
+  <node pkg="robot_state_publisher" name="robot_state_publisher" type="robot_state_publisher">
+  </node>
+  <node pkg="robot_state_publisher" name="robot_state_publisher_decompressed" type="robot_state_publisher">
+    <remap from="/joint_states" to="/joint_states_decompressed" />
+    <rosparam>
+      tf_prefix: decompressed
+    </rosparam>
+  </node>
+  <node pkg="joint_state_publisher" name="joint_state_publisher" type="joint_state_publisher">
+    <param name="use_gui" value="true" />
+  </node>
+  <node pkg="jsk_network_tools" type="joint-state-compressor.l" name="joint_state_compressor" output="screen"/>
+  <node pkg="jsk_network_tools" type="joint-state-decompressor.l" name="joint_state_decompressor" output="screen"/>
+  <node pkg="tf" type="static_transform_publisher" name="static_transform_publisher"
+        args="0 2 0 0 0 0 base_footprint decompressed/base_footprint 100" />
+</launch>

--- a/jsk_network_tools/msg/CompressedAngleVectorPR2.msg
+++ b/jsk_network_tools/msg/CompressedAngleVectorPR2.msg
@@ -1,0 +1,1 @@
+uint8[17] angles


### PR DESCRIPTION
Originally implemented in jsk_pr2_startup by Y.Furuta [https://github.com/jsk-ros-pkg/jsk_robot/pull/243]

Update the code to
* support robots not only pr2
* support linear-joint
* add simple executable to compress/decompress `sensor_msgs/JointStates`

I'm still wondering jsk_network_tools is the best package to locate it.
