### PR TITLE
NLopt CMakeLists.txt

### DIFF
--- a/3rdparty/nlopt/CMakeLists.txt
+++ b/3rdparty/nlopt/CMakeLists.txt
@@ -11,7 +11,7 @@ catkin_package(
     DEPENDS
     CATKIN_DEPENDS
     INCLUDE_DIRS
-    LIBRARIES
+    LIBRARIES nlopt_cxx
 )
 
 # set(NLOPTDIR ${CATKIN_PACKAGE_SHARE_DESTINATION}/jskeus/eus)


### PR DESCRIPTION
When I attempted to use the nlopt hydro package, the nlopt library was not being linked by packages that depended on it. I believe this is because catkin_package did not indicate that the library was being exported.

Thus I added nlopt_cxx library to catkin_package so that the library will be included by packages that depend on nlopt. 
