### PR TITLE
[nlopt] Fix nlopt compilation to export nlopt_cxx correctly.

### DIFF
--- a/3rdparty/nlopt/CMakeLists.txt
+++ b/3rdparty/nlopt/CMakeLists.txt
@@ -4,14 +4,20 @@ cmake_minimum_required(VERSION 2.4.6)
 
 find_package(catkin REQUIRED COMPONENTS mk)
 
-execute_process(COMMAND cmake -E chdir ${PROJECT_SOURCE_DIR} make -f ${PROJECT_SOURCE_DIR}/Makefile DSTDIR=${PROJECT_SOURCE_DIR}
-  MK_DIR=${mk_PREFIX}/share/mk)
+add_custom_target(libnlopt_cxx ALL
+  DEPENDS ${PROJECT_SOURCE_DIR}/lib/libnlopt_cxx.so)
+add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/lib/libnlopt_cxx.so
+  COMMAND cmake -E chdir ${PROJECT_SOURCE_DIR} make -f ${PROJECT_SOURCE_DIR}/Makefile DSTDIR=${PROJECT_SOURCE_DIR}
+  MK_DIR=${mk_PREFIX}/share/mk
+  COMMAND cp ${PROJECT_SOURCE_DIR}/lib/libnlopt* ${CATKIN_DEVEL_PREFIX}/lib
+  DEPENDS Makefile)
 
 catkin_package(
     DEPENDS
     CATKIN_DEPENDS
     INCLUDE_DIRS
     LIBRARIES nlopt_cxx
+    EXPORTED_TARGETS libnlopt_cxx
 )
 
 # set(NLOPTDIR ${CATKIN_PACKAGE_SHARE_DESTINATION}/jskeus/eus)


### PR DESCRIPTION
Fix for https://github.com/jsk-ros-pkg/jsk_control/issues/211

* compile libraries under source directory and after that copy to devel space.
* Use add_custom_command instead of execute_process