### PR TITLE
[jsk_topic_tools] Add service interface to change output topic of relay node

### DIFF
--- a/jsk_topic_tools/CMakeLists.txt
+++ b/jsk_topic_tools/CMakeLists.txt
@@ -13,7 +13,7 @@ add_message_files(
 )
 
 add_service_files(
-  FILES List.srv Update.srv
+  FILES List.srv Update.srv ChangeTopic.srv
 )
 
 generate_messages()
@@ -76,8 +76,9 @@ add_library(jsk_topic_tools SHARED
   src/diagnostic_nodelet.cpp
   src/series_boolean.cpp
   src/counter.cpp)
-  
+add_dependencies(jsk_topic_tools ${PROJECT_NAME}_gencpp)
 target_link_libraries(jsk_topic_tools ${catkin_LIBRARIES})
+
 if (NOT $ENV{ROS_DISTRO} STREQUAL "indigo")
   add_rostest(test/test_topic_buffer.test)
   add_rostest(test/test_topic_buffer_close_wait.test)
@@ -100,7 +101,7 @@ install(TARGETS topic_buffer_server topic_buffer_client jsk_topic_tools
 install(FILES jsk_topic_tools_nodelet.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
-install(DIRECTORY include/${PROJECT_NAME}/ 
+install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 # install(DIRECTORY include
 #   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}

--- a/jsk_topic_tools/include/jsk_topic_tools/relay_nodelet.h
+++ b/jsk_topic_tools/include/jsk_topic_tools/relay_nodelet.h
@@ -2,7 +2,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2013, Ryohei Ueda and JSK Lab
+ *  Copyright (c) 2013, JSK Lab
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -40,6 +40,7 @@
 #include <topic_tools/shape_shifter.h>
 #include <boost/thread.hpp>
 #include <boost/thread/mutex.hpp>
+#include <jsk_topic_tools/ChangeTopic.h>
 
 namespace jsk_topic_tools
 {
@@ -52,6 +53,15 @@ namespace jsk_topic_tools
   protected:
     virtual void connectCb();
     virtual void disconnectCb();
+    virtual bool changeOutputTopicCallback(
+      jsk_topic_tools::ChangeTopic::Request &req,
+      jsk_topic_tools::ChangeTopic::Response &res);
+    virtual ros::Publisher advertise(
+      boost::shared_ptr<topic_tools::ShapeShifter const> msg,
+      const std::string& topic);
+
+    boost::shared_ptr<topic_tools::ShapeShifter const> sample_msg_;
+    std::string output_topic_name_;
     boost::mutex mutex_;
     ros::Publisher pub_;
     ros::Subscriber sub_;
@@ -59,6 +69,7 @@ namespace jsk_topic_tools
     bool subscribing_;
     ros::NodeHandle pnh_;
     ros::TransportHints th_;
+    ros::ServiceServer change_output_topic_srv_;
   };
 }
 

--- a/jsk_topic_tools/srv/ChangeTopic.srv
+++ b/jsk_topic_tools/srv/ChangeTopic.srv
@@ -1,0 +1,2 @@
+string topic
+---


### PR DESCRIPTION
Add `~change_output_topic` service to jsk_topic_tools::Relay nodelet to change output topic on the fly.

It means that this relay node can behave like "inverse of mux" node.