### PR TITLE
[image_view2] Add left_up_origin flag to ImageMarker2 to draw text from left upper origin

### DIFF
--- a/jsk_ros_patch/image_view2/image_view2.cpp
+++ b/jsk_ros_patch/image_view2/image_view2.cpp
@@ -411,9 +411,22 @@ namespace image_view2{
     if ( scale == 0 ) scale = 1.0;
     text_size = cv::getTextSize(marker->text.c_str(), font_,
                                 scale, scale, &baseline);
-    cv::Point origin = cv::Point(marker->position.x - text_size.width/2,
-                                 marker->position.y - baseline-3);
-    cv::putText(draw_, marker->text.c_str(), origin, font_, scale, DEFAULT_COLOR);
+    cv::Point origin;
+    if (marker->left_up_origin) {
+      origin = cv::Point(marker->position.x,
+                         marker->position.y);
+    }
+    else {
+      origin = cv::Point(marker->position.x - text_size.width/2,
+                         marker->position.y - baseline-3);
+    }
+    if (marker->filled) {
+      cv::putText(draw_, marker->text.c_str(), origin, font_, scale, DEFAULT_COLOR, marker->filled);
+      
+    }
+    else {
+      cv::putText(draw_, marker->text.c_str(), origin, font_, scale, DEFAULT_COLOR);
+    }
   }
 
   void ImageView2::drawLineStrip3D(const image_view2::ImageMarker2::ConstPtr& marker,

--- a/jsk_ros_patch/image_view2/msg/ImageMarker2.msg
+++ b/jsk_ros_patch/image_view2/msg/ImageMarker2.msg
@@ -40,3 +40,4 @@ std_msgs/ColorRGBA[] outline_colors # a color for each line, point, etc.
 
 string[] frames # used for FRAMES, tf names
 string text             # used for TEXT, draw size of text is scale
+bool left_up_origin     # draw text from left up origin


### PR DESCRIPTION
* add left_up_origin flag to ImageMarker2 to set the origin of text to left upper corner
* support filled flag in draw text type