### PR TITLE
[jsk_topic_tools] Add Passthrough nodelet to relay topics during specified duration

### DIFF
--- a/jsk_topic_tools/CMakeLists.txt
+++ b/jsk_topic_tools/CMakeLists.txt
@@ -13,7 +13,7 @@ add_message_files(
 )
 
 add_service_files(
-  FILES List.srv Update.srv ChangeTopic.srv
+  FILES List.srv Update.srv ChangeTopic.srv PassthroughDuration.srv
 )
 
 generate_messages()
@@ -55,6 +55,8 @@ jsk_topic_tools_nodelet(src/mux_nodelet.cpp
   "jsk_topic_tools/MUX" "mux")
 jsk_topic_tools_nodelet(src/relay_nodelet.cpp
   "jsk_topic_tools/Relay" "relay")
+jsk_topic_tools_nodelet(src/passthrough_nodelet.cpp
+  "jsk_topic_tools/Passthrough" "passthrough")
 jsk_topic_tools_nodelet(src/block_nodelet.cpp
   "jsk_topic_tools/Block" "block")
 jsk_topic_tools_nodelet(src/snapshot_nodelet.cpp

--- a/jsk_topic_tools/include/jsk_topic_tools/passthrough_nodelet.h
+++ b/jsk_topic_tools/include/jsk_topic_tools/passthrough_nodelet.h
@@ -1,0 +1,100 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2015, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#ifndef PASSTHROUGH_NODELET_H_
+#define PASSTHROUGH_NODELET_H_
+
+#include <nodelet/nodelet.h>
+#include <topic_tools/shape_shifter.h>
+#include <boost/thread.hpp>
+#include <boost/thread/mutex.hpp>
+#include <jsk_topic_tools/PassthroughDuration.h>
+
+namespace jsk_topic_tools
+{
+  class Passthrough : public nodelet::Nodelet
+  {
+  public:
+    typedef ros::MessageEvent<topic_tools::ShapeShifter> ShapeShifterEvent;
+  protected:
+    /** @brief
+     *  Initialization function.
+     *
+     *  Setup subscriber for ~input topic.
+     */
+    virtual void onInit();
+
+    /** @brief
+     *  Callback function for ~input.
+     *  It advertise ~output topic according to the definition of input topic
+     *  at the first time.
+     *  After that, Passthrough relays ~input topic to ~output topic
+     *  until end_time_.
+     *
+     *  If ros::Time::now() goes over end_time_, publish_requested_ flag is set
+     *  to false.
+     */
+    virtual void inputCallback(const boost::shared_ptr<topic_tools::ShapeShifter const>& msg);
+
+    /** @brief
+     *  Callback function for ~request_duration service.
+     *
+     *  This callback reqtrieves jsk_topic_tools::PassThroughDuration and
+     *  it has a duration to relay message.
+     *  In side of this function, end_time_ is updated relative to ros::Time::now().
+     *
+     *  If duration is equivalent to ros::Duration(0), it is interpreted as eternal.
+     */
+    virtual bool requestDurationCallback(
+      jsk_topic_tools::PassthroughDuration::Request &req,
+      jsk_topic_tools::PassthroughDuration::Response &res);
+    
+    virtual ros::Publisher advertise(
+      boost::shared_ptr<topic_tools::ShapeShifter const> msg,
+      const std::string& topic);
+    
+    ros::Time finish_time_;
+    bool publish_requested_;
+    boost::mutex mutex_;
+    ros::Publisher pub_;
+    ros::Subscriber sub_;
+    bool advertised_;
+    ros::NodeHandle pnh_;
+    ros::Time end_time_;
+    ros::ServiceServer request_duration_srv_;
+  };
+}
+
+#endif

--- a/jsk_topic_tools/jsk_topic_tools_nodelet.xml
+++ b/jsk_topic_tools/jsk_topic_tools_nodelet.xml
@@ -41,6 +41,12 @@
       relay a topic message from ~input to ~output.
     </description>
   </class>
+  <class name="jsk_topic_tools/Passthrough" type="Passthrough"
+         base_class_type="nodelet::Nodelet">
+    <description>
+      passthrough a topic message from ~input to ~output during specified time.
+    </description>
+  </class>
   <class name="jsk_topic_tools/Block" type="Block"
          base_class_type="nodelet::Nodelet">
     <description>

--- a/jsk_topic_tools/src/passthrough_nodelet.cpp
+++ b/jsk_topic_tools/src/passthrough_nodelet.cpp
@@ -1,0 +1,124 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+#include <pluginlib/class_list_macros.h>
+#include "jsk_topic_tools/passthrough_nodelet.h"
+
+namespace jsk_topic_tools
+{
+
+  void Passthrough::onInit()
+  {
+    advertised_ = false;
+    publish_requested_ = false;
+    pnh_ = getPrivateNodeHandle();
+    sub_ = pnh_.subscribe<topic_tools::ShapeShifter>(
+      "input", 1,
+      &Passthrough::inputCallback, this);
+    request_duration_srv_ = pnh_.advertiseService(
+      "request_duration", &Passthrough::requestDurationCallback, this);
+  }
+
+  bool Passthrough::requestDurationCallback(
+    jsk_topic_tools::PassthroughDuration::Request &req,
+    jsk_topic_tools::PassthroughDuration::Response &res)
+  {
+    boost::mutex::scoped_lock lock(mutex_);
+    // special case of ros::Duration(0), it means eternal
+    if (req.duration == ros::Duration(0)) {
+      end_time_ = ros::Time(0);
+      publish_requested_ = true;
+    }
+    else {
+      ros::Time now = ros::Time::now();
+      if (publish_requested_) {
+        // check need to update end_time or not
+        if (end_time_ < now + req.duration) {
+          end_time_ = now + req.duration;
+        }
+      }
+      else {
+        publish_requested_ = true;
+        end_time_ = now + req.duration;
+      }
+    }
+    return true;
+  }
+  
+  void Passthrough::inputCallback(
+    const boost::shared_ptr<topic_tools::ShapeShifter const>& msg)
+  {
+    boost::mutex::scoped_lock lock(mutex_);
+    if (!advertised_) {
+      // this block is called only once
+      // in order to advertise topic.
+      // we need to subscribe at least one message
+      // in order to detect message definition.
+      pub_ = advertise(msg, "output");
+      advertised_ = true;
+    }
+    else {
+      if (publish_requested_) {
+        // check time
+        ros::Time now = ros::Time::now();
+        if (end_time_ == ros::Time(0) || // ros::Time(0) means eternal publishing
+            end_time_ > now) {
+          pub_.publish(msg);
+        }
+        // check it goes over end_time_ 
+        if (end_time_ != ros::Time(0) && end_time_ < now) {
+          publish_requested_ = false;
+        }
+      }
+    }
+  }
+
+  ros::Publisher Passthrough::advertise(
+    boost::shared_ptr<topic_tools::ShapeShifter const> msg,
+    const std::string& topic)
+  {
+    // ros::SubscriberStatusCallback connect_cb
+    //   = boost::bind( &Passthrough::connectCb, this);
+    // ros::SubscriberStatusCallback disconnect_cb
+    //   = boost::bind( &Passthrough::disconnectCb, this);
+    ros::AdvertiseOptions opts(topic, 1,
+                               msg->getMD5Sum(),
+                               msg->getDataType(),
+                               msg->getMessageDefinition());
+    opts.latch = true;
+    return pnh_.advertise(opts);
+  }
+}
+
+typedef jsk_topic_tools::Passthrough Passthrough;
+PLUGINLIB_EXPORT_CLASS(Passthrough, nodelet::Nodelet)

--- a/jsk_topic_tools/srv/PassthroughDuration.srv
+++ b/jsk_topic_tools/srv/PassthroughDuration.srv
@@ -1,0 +1,2 @@
+duration duration
+---


### PR DESCRIPTION
Passthrough is a nodelet to relay topics only for specified duratoin.

For example, you can relay input poointcloud for 10 seconds to get one recognition result by this node.