### PR TITLE
do not overwrite hydro_parent/deve/setup.bash for chaining catkin worksp...

### DIFF
--- a/jsk.rosbuild
+++ b/jsk.rosbuild
@@ -237,7 +237,6 @@ function compile-pkg {
     (cd $ROS_INSTALLDIR_SRC &&
         $COMMAND wget https://raw.github.com/jsk-ros-pkg/jsk_travis/master/rosdep-install.sh -O - | ROS_DISTRO=$DISTRIBUTION $COMMAND bash)
 
-    $COMMAND source /opt/ros/$DISTRIBUTION/setup.sh
     env | grep ROS
     # do compile
     (cd $ROS_INSTALLDIR && LC_ALL=C $COMMAND catkin build --no-status $PACKAGES)


### PR DESCRIPTION
...aces

普通にjsk.rosbuildを実行してもroscd hrpsysなどでhydro_parentの方に行きませんでした．

違っていたら申し訳ありませんが，hydro_parentはchaining_catkin_workspacesを意図しているのかと思ったのですが，その場合この行（hrpsys_parentのbuildとhrpsysのbuildの間）はあったらダメなのではないでしょうか？

http://wiki.ros.org/catkin/Tutorials/workspace_overlaying#Chaining_catkin_workspaces