### PR TITLE
need autoconf for openrtm_aist

### DIFF
--- a/jsk.rosbuild
+++ b/jsk.rosbuild
@@ -138,6 +138,9 @@ function setup-ros {
     fi
     $COMMAND sudo apt-get upgrade $YES
     $COMMAND sudo apt-get -qq $YES install ros-${DISTRIBUTION}-rosbash python-rosdep python-wstool python-catkin-tools python-pip
+    if [ "$USE_SOURCE" != "" ]; then
+        $COMMAND sudo apt-get -qq $YES install autoconf # for openrtm_aist
+    fi
     if [ "$USE_SOURCE" == "full" ]; then
         $COMMAND sudo apt-get -qq $YES install python-rosinstall-generator
         $COMMAND sudo apt-get -qq $YES install libftdi-dev libgstreamer0.10-dev libgst-dev libgstreamer-plugins-base0.10-dev


### PR DESCRIPTION
jsk.rosbuildを実行したところ，autoconfが入っておらず，
```bash
commands were not found: autoconf259 autoconf-2.59 autoconf
```
と怒られてopenrtm_aistのbuildがfailしました．

どこにパッチを当てるべきかよく分からなかったのでひとまずjsk.rosbuildに書いてみましたが，以下のように https://github.com/tork-a/openrtm_aist-release にPRを出すべきなのでしょうか？

https://github.com/eisoku9618/openrtm_aist-release/blob/update-dependency/package.xml#L28

ご確認よろしくお願いします．