### PR TITLE
[jsk.rosbuild] Run rosdep for ros/hydro and ros/hydo_parent at once

### DIFF
--- a/jsk.rosbuild
+++ b/jsk.rosbuild
@@ -218,13 +218,12 @@ function compile-pkg {
 
     echo "hddtemp hddtemp/daemon boolean false" | $COMMAND sudo debconf-set-selections
 
+    # rosdep install
+    (cd ${ROS_INSTALLDIR}/src &&
+        $COMMAND wget https://raw.github.com/jsk-ros-pkg/jsk_travis/master/rosdep-install.sh -O - | ROS_DISTRO=$DISTRIBUTION ROS_PACKAGE_PATH="$ROS_PACKAGE_PATH:$HOME/ros/hydro_parent/src:$HOME/ros/hydro/src" $COMMAND bash)
     ## do compile for upstream
     $COMMAND source /opt/ros/$DISTRIBUTION/setup.sh
     if [ -e ${ROS_INSTALLDIR}_parent/src ]; then
-        # rosdep install
-        (cd ${ROS_INSTALLDIR}_parent/src &&
-            $COMMAND wget https://raw.github.com/jsk-ros-pkg/jsk_travis/master/rosdep-install.sh -O - | ROS_DISTRO=$DISTRIBUTION $COMMAND bash)
-        #
         $COMMAND source /opt/ros/$DISTRIBUTION/setup.sh
         #
         (cd ${ROS_INSTALLDIR}_parent && LC_ALL=C $COMMAND catkin build --no-status)
@@ -235,9 +234,6 @@ function compile-pkg {
         $COMMAND source ${ROS_INSTALLDIR}_parent/devel/setup.sh
     fi
 
-    # rosdep install
-    (cd $ROS_INSTALLDIR_SRC &&
-        $COMMAND wget https://raw.github.com/jsk-ros-pkg/jsk_travis/master/rosdep-install.sh -O - | ROS_DISTRO=$DISTRIBUTION $COMMAND bash)
     # need to resource setup.sh for loading configuratoin of newly installed package by rosdep
     $COMMAND source /opt/ros/$DISTRIBUTION/setup.sh
     if [ -e ${ROS_INSTALLDIR}_parent/src ]; then


### PR DESCRIPTION
in order to ignore packages which is in local workspace correctly