### PR TITLE
[opt_camera] support pan control of panorama view, use enum for flip/sma...

### DIFF
--- a/opt_camera/cfg/OptNM33Camera.cfg
+++ b/opt_camera/cfg/OptNM33Camera.cfg
@@ -42,8 +42,25 @@ gen.add("zoom",         double_t, 0, "Zoom",      100,    1, 1500);
 
 gen.add("firmwareversion", str_t, 0, "Firemware version", "");
 gen.add("serialid",        str_t, 0, "Serial Number", "");
-gen.add("flipscreen",      int_t, 0, "Flip screen",        0,   0,   3);
-gen.add("smallhemisphere", int_t, 0, "Small Hemisphere",   1,   0,   9);
+gen.add("flipscreen",      int_t, 0, "Flip screen",        0,
+        edit_method = gen.enum( [gen.const("noraml",      int_t, 0, "Normal mode"),
+                                 gen.const("horizontal",  int_t, 1, "Flopping around Y-axis"),
+                                 gen.const("vertical",    int_t, 2, "Flopping around X-axis"),
+                                 gen.const("horizontal_vertical",int_t, 3, "Flopping around boath axes")],
+                                "Enum to set filpmode."))
+
+gen.add("smallhemisphere", int_t, 0, "Small Hemisphere",   1,
+        edit_method = gen.enum( [gen.const("none",         int_t, 0, "Do not display smallhemisphere"),
+                                 gen.const("top_left",     int_t, 1, "Display smallhemisphere Top Left"),
+                                 gen.const("top_middle",   int_t, 2, "Display smallhemisphere Top Middle"),
+                                 gen.const("top_right",    int_t, 3, "Display smallhemisphere Top Right"),
+                                 gen.const("middle_left",  int_t, 4, "Display smallhemisphere Middle Left"),
+                                 gen.const("middle_middle",int_t, 5, "Display smallhemisphere Middle Middle"),
+                                 gen.const("middle_right", int_t, 6, "Display smallhemisphere Middle Right"),
+                                 gen.const("bottom_left",  int_t, 7, "Display smallhemisphere Bottom Left"),
+                                 gen.const("bottom_middle",int_t, 8, "Display smallhemisphere Bottome Middle"),
+                                 gen.const("bottom_right", int_t, 9, "Display smallhemisphere Bottom Right")],
+                                "Enum to set smallsphere mode."))
 gen.add("medianfilter",   bool_t, 0, "Median Filter",      False);
 
 gen.add("jpegquality",     int_t, 0, "Jpeg Quality",      75,   0,  99);


### PR DESCRIPTION
...ll in reconfigure gui

set 
- mode: panorama
- flipscreen : horizontal_vertical
- smallhemisphere : none

and move pan slider to modify direction

![screenshot_from_2015-03-18 16 02 30](https://cloud.githubusercontent.com/assets/493276/6704185/91c06cf0-cd88-11e4-8051-986899a5dce8.png)
![screenshot_from_2015-03-18 16 02 16](https://cloud.githubusercontent.com/assets/493276/6704187/93301b12-cd88-11e4-93a9-401a82670a03.png)

```
 hrpuser@hrp2016v:~/ros/hydro/src/jsk-ros-pkg/jsk_common/opt_camera$ catkin bt && roslaunch launch/optnm33_camera_node.launch  camera_index:=0
```

