### PR TITLE
Downward static

### DIFF
--- a/3rdparty/downward/CMakeLists.txt
+++ b/3rdparty/downward/CMakeLists.txt
@@ -7,7 +7,7 @@ catkin_package()
 
 add_custom_command(
   OUTPUT installed
-  COMMAND make -f ${PROJECT_SOURCE_DIR}/Makefile
+  COMMAND \$\(MAKE\) -f ${PROJECT_SOURCE_DIR}/Makefile
 )
 add_custom_command(
   OUTPUT ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/scripts

--- a/3rdparty/downward/package.xml
+++ b/3rdparty/downward/package.xml
@@ -18,6 +18,7 @@
   <build_depend>flex</build_depend>
   <build_depend>bison</build_depend>
   <build_depend>gawk</build_depend>
+  <build_depend>g++-static</build_depend>
   <build_depend>rospack</build_depend>
   <build_depend>roslib</build_depend>
   <build_depend>mk</build_depend>


### PR DESCRIPTION
First commit adds a `build_depend` on `g++-static` for `downward`. It seems that upstream `downward` forces all non-osx builds to use static linking. These libraries are provided automatically in Ubuntu, but reside in separate packages for Fedora.

rosdep key for `g++-static`: https://github.com/ros/rosdistro/blob/942f1592dbf0d208fc3d48c5cb2d70d3acb0050a/rosdep/base.yaml#L678-L680

Second commit invokes recursive call to `make` properly. See https://www.gnu.org/software/make/manual/html_node/MAKE-Variable.html#MAKE-Variable for details.

Example build failure: http://csc.mcs.sdsmt.edu/jenkins/job/ros-indigo-downward_binaryrpm_heisenbug_x86_64/25/consoleFull

Thanks,

--scott