### PR TITLE
[jsk.rosbuild] Add garaemon/pcl_conversions to resolve fatal bug 

### DIFF
--- a/jsk.rosbuild
+++ b/jsk.rosbuild
@@ -283,6 +283,10 @@ EOF
     if [ "$USE_SOURCE" != "" ]; then
         wget  'https://raw.github.com/jsk-ros-pkg/jsk_common/master/jsk.rosinstall' -O /tmp/jsk.rosinstall.$$
         cat /tmp/jsk.rosinstall.$$ >> /tmp/rosinstall.$$
+        if [ "$DISTRIBUTION" = "hydro" ]; then
+            wget  'https://raw.github.com/jsk-ros-pkg/jsk_common/master/jsk.install.hydro' -O /tmp/jsk.rosinstall.hydro.$$
+            cat /tmp/jsk.rosinstall.hydro.$$ >> /tmp/rosinstall.$$
+        fi
         if [ "$RTM_ROS_ROBOTICS" = "true" ]; then
             cat <<EOF > /tmp/rtm-ros-robotics.rosinstall.$$
 - git:

--- a/jsk.rosinstall
+++ b/jsk.rosinstall
@@ -191,7 +191,3 @@
 - hg:
     local-name: multisense
     uri: 'https://bitbucket.org/crl/multisense_ros'
-- git:
-    local-name: perception_pcl
-    uri: 'https://github.com/garaemon/perception_pcl.git'
-    version: hydro-devel

--- a/jsk.rosinstall.hydro
+++ b/jsk.rosinstall.hydro
@@ -1,0 +1,8 @@
+- git:
+    local-name: perception_pcl
+    uri: 'https://github.com/garaemon/perception_pcl.git'
+    version: hydro-devel
+- git:
+    local-name: pcl_conversions
+    uri: 'https://github.com/garaemon/pcl_conversions.git'
+    version: hydro-devel


### PR DESCRIPTION
and use garaemon/pcl_conversions and garaemon/pcl_ros only for hydro users

* Add jsk.rosinstall.hydro for hydro
* Add garaemon/pcl_conversions and garaemon/perception_pcl to jsk.rosinstall.hydro

Because these repositories do not merge critical pull-request yet.
