### PR TITLE
[jsk_tool] Add script to add git commit aliases like commit-ueda

### DIFF
--- a/jsk_tools/src/git_commit_alias.py
+++ b/jsk_tools/src/git_commit_alias.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+# Generate commit aliases for jsk-ros-pkg developers
+import sys
+import subprocess
+try:
+    from pygithub3 import Github
+except:
+    print """Install pygithub3 via
+    sudo pip install pygithub3
+    """
+    sys.exit(1)
+
+from getpass import getpass
+user = raw_input('User name: ')
+pw = getpass('Password: ')
+
+gh = Github(login=user, password=pw)
+result = gh.orgs.members.list('jsk-ros-pkg')
+for page in result:
+    for member in page:
+        user = gh.users.get(member.login)
+        try:
+            name = user.name
+            alias_name = name
+            email = user.email
+            if not email or email == "":
+                raise Exception("No email specified")
+            if len(alias_name.split(" ")) > 0:
+                alias_name = name.split(" ")[-1]
+            alias_command = "commit-%s" % alias_name.lower()
+            alias = "commit --author='%s <%s>'" % (name, email)
+            subprocess.check_call(["git", "config", "--global", 
+                                   "alias.%s" % alias_command,
+                                   alias])
+            print "Added %s" % (alias_command)
+        except:
+            print "Failed to generate alias for %s" % (member.login)
+


### PR DESCRIPTION
You can add commit aliases liks `commit-ueda` and `commit-murooka` of jsk-ros-pkg developers, it's useful to develop software on one-machine/one-user.

Usage:
```
rosrun jsk_tools git_commit_alias.py
```