### PR TITLE
[jsk_tools] Add rossetdefault, rosdefault to zshrc.ros

### DIFF
--- a/jsk_tools/README.md
+++ b/jsk_tools/README.md
@@ -39,3 +39,34 @@ set ROS_MASTER_URI to http://pr1040:11311
 [http://pr1040:11311] user@host $ echo $ROS_MASTER_URI
 http://pr1040:11311
 ```
+
+
+rosdefault
+----------
+Setup `ROS_MASTER_URI` with default hostname written in `~/.rosdefault`.  
+
+```sh
+$ cat ~/.rosdefault
+pr1040
+$ rosdefault
+set ROS_MASTER_URI to http://pr1040:11311
+```
+
+It is recommended to run `rosdefault` in your .bashrc or .zshrc.
+
+
+rossetdefault
+-------------
+Setup your default hostname.  
+After running this command, you can setup `ROS_MASTER_URI` with default hostname by `rosdefault`.  
+(default hostname will be stored at `~/.rosdefault`)
+
+```sh
+# rossetdefault ${hostname}
+# default: hostname=local
+$ rossetdefault baxter
+set ROS_MASTER_URI to http://baxter:11311
+$ bash
+$ rosdefault
+set ROS_MASTER_URI to http://baxter:11311
+```

--- a/jsk_tools/env-hooks/99.jsk_tools.bash
+++ b/jsk_tools/env-hooks/99.jsk_tools.bash
@@ -1,6 +1,27 @@
 #!/bin/bash
 # -*- mode: Shell-script; -*-
 
+function rossetdefault() {
+    local hostname=${1-"local"}
+    local ros_port=${2-"11311"}
+    echo "$hostname\n$ros_port" > ~/.rosdefault
+    rosdefault
+}
+function rosdefault() {
+    if [ -f ~/.rosdefault ]; then
+        local hostname="$(sed -n 1p ~/.rosdefault)"
+        local ros_port="$(sed -n 2p ~/.rosdefault)"
+    else
+        local hostname="local"
+        local ros_port="11311"
+    fi
+    if [ "$hostname" = "local" ]; then
+        rossetlocal $ros_port
+    else
+        rossetmaster $hostname $ros_port
+    fi
+}
+
 function rossetmaster() { # 自分のよく使うロボットのhostnameを入れる
     local hostname=${1-"pr1040"}
     local ros_port=${2-"11311"}

--- a/jsk_tools/env-hooks/99.jsk_tools.zsh
+++ b/jsk_tools/env-hooks/99.jsk_tools.zsh
@@ -1,5 +1,26 @@
 #!/bin/zsh
-# -*- mode: shell-script -*-
+# -*- mode: shell-script; -*-
+
+function rossetdefault() {
+    local hostname=${1-"local"}
+    local ros_port=${2-"11311"}
+    echo "$hostname\n$ros_port" > ~/.rosdefault
+    rosdefault
+}
+function rosdefault() {
+    if [ -f ~/.rosdefault ]; then
+        local hostname="$(sed -n 1p ~/.rosdefault)"
+        local ros_port="$(sed -n 2p ~/.rosdefault)"
+    else
+        local hostname="local"
+        local ros_port="11311"
+    fi
+    if [ "$hostname" = "local" ]; then
+        rossetlocal $ros_port
+    else
+        rossetmaster $hostname $ros_port
+    fi
+}
 
 function rossetmaster() {
     if [ "${ZSH_REMATCH}" = "" ]; then
@@ -88,4 +109,3 @@ function rost() {
         rosn $node
     fi
 }
-


### PR DESCRIPTION
Usage
-----
```
user@host $ rossetdefault pr1040
set ROS_MASTER_URI to http://pr1040:11311
[http://pr1040:11311] user@host $
user@host $ rosdefault
set ROS_MASTER_URI to http://pr1040:11311
[http://pr1040:11311] user@host $
user@host $ rossetdefault local
user@host $ rosdefault
set ROS_MASTER_URI to http://localhost:11311
```
It is recommended to write `rosdefault` in your .bashrc or .zshrc.