### PR TITLE
[jsk_network_tools] Use 1500*8 bits as default packet_size

### DIFF
--- a/jsk_network_tools/README.md
+++ b/jsk_network_tools/README.md
@@ -182,7 +182,7 @@ by `~message` parameter.
 * `~send_rate` (default: `2`)
 
   Fixed rate in Hz to send message.
-* `~packet_size` (default: `1000`)
+* `~packet_size` (default: `12000`)
 
   Packet size of UDP. ROS message will be splitted into the packets
   of `~packet_size`. Unit is byte.

--- a/jsk_network_tools/scripts/silverhammer_highspeed_receiver.py
+++ b/jsk_network_tools/scripts/silverhammer_highspeed_receiver.py
@@ -40,7 +40,7 @@ class SilverHammerReceiver:
                                                 latch=self.latch)
         self.socket_server = socket(AF_INET, SOCK_DGRAM)
         self.socket_server.bind((self.receive_ip, self.receive_port))
-        self.packet_size = rospy.get_param("~packet_size", 1000)   #2Hz
+        self.packet_size = rospy.get_param("~packet_size", 1500 * 8)   #2Hz
         self.packets = []
         self.launched_time = rospy.Time.now()
         self.last_received_time = rospy.Time(0)

--- a/jsk_network_tools/scripts/silverhammer_highspeed_streamer.py
+++ b/jsk_network_tools/scripts/silverhammer_highspeed_streamer.py
@@ -41,7 +41,7 @@ class SilverHammerStreamer:
         self.send_num = 0
         self.rate = rospy.get_param("~send_rate", 2)   #2Hz
         self.socket_client = socket(AF_INET, SOCK_DGRAM)
-        self.packet_size = rospy.get_param("~packet_size", 1000)   #2Hz
+        self.packet_size = rospy.get_param("~packet_size", 1500 * 8) # for MTU:=1500
         subscriber_info = subscribersFromMessage(self.message_class())
         self.messages = {}
         self.subscribe(subscriber_info)


### PR DESCRIPTION
[jsk_network_tools] Use 1500*8 bits as default packet_size for MTU:=1500
environment in silverhammer_highspeed communication