### PR TITLE
[jsk_network_tools] bugfix: fix rmem_max value; set bash option to check command executed successfly

### DIFF
--- a/jsk_network_tools/scripts/expand_udp_receive_buffer.sh
+++ b/jsk_network_tools/scripts/expand_udp_receive_buffer.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
+set -eu
+
 if [ "`cat /etc/sysctl.conf | grep net.core.rmem_max`" = "" ]; then
-    echo 'net.core.rmem_max = 4259840' >> /etc/sysctl.conf
+    echo 'net.core.rmem_max = 782237696' >> /etc/sysctl.conf
     sysctl -p
-    echo "changed kernel parameter"
 else
-    echo "nothing to change"
+    sed -i -e "s/net.core.rmem_max = \(.*\)/net.core.rmem_max = 782237696/g" /etc/sysctl.conf
+    sysctl -p
 fi


### PR DESCRIPTION
@garaemon Thank you for advise. I mistook value, very sorry.
also added shell option to check if this command executed successfly.