### PR TITLE
[jsk_network_tools] add set send_rate service for lowspeed streamer

### DIFF
--- a/jsk_network_tools/launch/simple_silverhammer_sample.launch
+++ b/jsk_network_tools/launch/simple_silverhammer_sample.launch
@@ -7,6 +7,7 @@
       <rosparam>
         message: jsk_network_tools/FC2OCS
         to_port: 1024
+        send_rate: 1.0
       </rosparam>
       <remap from="~input" to="fc2ocs_original" />
     </node>
@@ -26,6 +27,7 @@
       <rosparam>
         message: jsk_network_tools/OCS2FC
         to_port: 1025
+        send_rate: 1.0
       </rosparam>
       <remap from="~input" to="ocs2fc_original" />
     </node>

--- a/jsk_network_tools/scripts/silverhammer_lowspeed_streamer.py
+++ b/jsk_network_tools/scripts/silverhammer_lowspeed_streamer.py
@@ -15,6 +15,7 @@ import sys
 import roslib
 from roslib.message import get_message_class
 from std_msgs.msg import Time
+from std_srvs.srv import Empty
 
 class SilverHammerLowspeedStreamer():
     def __init__(self):
@@ -49,6 +50,18 @@ class SilverHammerLowspeedStreamer():
                                           self.sendTimerCallback)
         self.diagnostic_timer = rospy.Timer(rospy.Duration(1.0 / 10),
                                             self.diagnosticTimerCallback)
+        self.send_rate_service = rospy.Service('set_send_rate', Empty, self.setSendRate)
+
+    def setSendRate(self, _=None): # empty call
+        if self.event_driven:
+            rospy.logerr("failed to change send_rate. event_driven is enabled.")
+            return
+        if self.send_timer.is_alive():
+            self.send_timer.shutdown()
+        self.send_rate = rospy.get_param("~send_rate", 1)
+        rospy.loginfo("send_rate is set to %f" % self.send_rate)
+        self.send_timer = rospy.Timer(rospy.Duration(1 / self.send_rate),
+                                      self.sendTimerCallback)
 
     def diagnosticTimerCallback(self, event):
         self.diagnostic_updater.update()


### PR DESCRIPTION
we can change `send_rate` by reloading param:

```
rosparam set /silverhammer/ocs_streamer/send_rate 10.0
rosservice call /silverhammer/set_send_rate
```
