### PR TITLE
[jsk_tools] Add launch to record axis camera

### DIFF
--- a/jsk_tools/launch/record_axis_camera.launch
+++ b/jsk_tools/launch/record_axis_camera.launch
@@ -1,0 +1,26 @@
+<launch>
+  <arg name="filename" default="output.avi" />
+  <arg name="hostname" default="133.11.216.141" />
+  <arg name="username" default="root" />
+
+  <arg name="ask_password" default="true" />
+  <arg unless="$(arg ask_password)" name="password" />
+
+  <group ns="axis">
+    <node name="axis_camera" pkg="axis_camera" type="axis.py" >
+      <param name="hostname" value="$(arg hostname)" />
+      <param name="username" value="$(arg username)" />
+      <param if="$(arg ask_password)" name="password"
+             command="python -c 'import getpass;passwd=getpass.getpass(&quot;Axis password?: &quot;);print(passwd)'" />
+      <param unless="$(arg ask_password)" name="password" value="$(arg password)" />
+    </node>
+    <node name="image_transport_republisher" pkg="image_transport" type="republish" args="compressed">
+      <remap from="in" to="image_raw" />
+      <remap from="out" to="image_raw" />
+    </node>
+    <node name="video_recorder" pkg="image_view" type="video_recorder" output="screen">
+      <remap from="image" to="image_raw" />
+      <param name="filename" value="$(arg filename)" />
+    </node>
+  </group>
+</launch>

--- a/jsk_tools/package.xml
+++ b/jsk_tools/package.xml
@@ -23,6 +23,7 @@
   <run_depend>rosgraph_msgs</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>rqt_reconfigure</run_depend>
+  <run_depend>axis_camera</run_depend>
   <!-- <build_depend>mjpeg_server</build_depend> -->
   <!-- <run_depend>mjpeg_server</run_depend> -->
   <!-- <test_depend>mjpeg_server</test_depend> -->


### PR DESCRIPTION
```sh
$ roslaunch jsk_tools record_axis_camera.launch
... logging to /home/wkentaro/.ros/log/9569da06-14b6-11e5-80a8-7831c1bb6b6c/roslaunch-cobra-9917.log
Checking log directory for disk usage. This may take awhile.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

Axis password?:
```

or

```sh
$ roslaunch jsk_tools record_axis_camera.launch ask_password:=false password:=XXXX
```

default output file should be saved as `~/.ros/output.avi' (without no customization)