### PR TITLE
[jsk.rosinstall] jsk_pr2_startup/pr2.launch requires launch file in

### DIFF
--- a/jsk.rosinstall
+++ b/jsk.rosinstall
@@ -158,10 +158,10 @@
     local-name: pr2_apps
     uri: 'https://github.com/PR2/pr2_apps.git'
     version: hydro-devel
-# - git:
-#     local-name: pr2_gripper_sensor
-#     uri: 'https://github.com/PR2/pr2_gripper_sensor.git'
-#     version: hydro-devel
+- git:
+    local-name: pr2_gripper_sensor
+    uri: 'https://github.com/PR2/pr2_gripper_sensor.git'
+    version: hydro-devel
 - git:
     local-name: pr2_common_actions
     uri: 'https://github.com/PR2/pr2_common_actions.git'


### PR DESCRIPTION
pr2_gripper_sensor_action

this is to avoid error in jsk_pr2_startup/pr2.launch because of missing launch file.
it is solved only in ros-shadow-fixed.