### PR TITLE
[jsk_topic_tools] Introduce new nodelet manager called standalone_complexed_nodelet.

### DIFF
--- a/jsk_topic_tools/CMakeLists.txt
+++ b/jsk_topic_tools/CMakeLists.txt
@@ -27,6 +27,7 @@ catkin_package(
 
 include_directories(include ${catkin_INCLUDE_DIRS})
 #include_directories(${Boost_INCLUDE_DIRS})
+add_executable(standalone_complexed_nodelet src/standalone_complexed_nodelet.cpp)
 add_executable(topic_buffer_server src/topic_buffer_server.cpp)
 add_executable(topic_buffer_client src/topic_buffer_client.cpp)
 add_executable(transform_merger src/transform_merger.cpp)
@@ -39,7 +40,7 @@ add_dependencies(topic_buffer_server ${PROJECT_NAME}_gencpp)
 add_dependencies(topic_buffer_client ${PROJECT_NAME}_gencpp)
 target_link_libraries(topic_buffer_server ${catkin_LIBRARIES})
 target_link_libraries(topic_buffer_client ${catkin_LIBRARIES})
-
+target_link_libraries(standalone_complexed_nodelet ${catkin_LIBRARIES})
 
 include(${PROJECT_SOURCE_DIR}/cmake/nodelet.cmake)
 
@@ -97,6 +98,7 @@ endif(NOT $ENV{ROS_DISTRO} STREQUAL "indigo")
 
 install(TARGETS topic_buffer_server topic_buffer_client jsk_topic_tools
   ${jsk_topic_tools_nodelet_executable_names}
+  standalone_complexed_nodelet
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/jsk_topic_tools/launch/standalone_complexed_nodelet_sample.launch
+++ b/jsk_topic_tools/launch/standalone_complexed_nodelet_sample.launch
@@ -1,0 +1,24 @@
+<launch>
+  <node pkg="rostopic" type="rostopic" name="input" args="pub input std_msgs/String '{data: input}' -r 10" />
+  <node pkg="jsk_topic_tools" type="standalone_complexed_nodelet" name="standalone_complexed_nodelet"
+        output="screen">
+    <rosparam>
+      nodelets:
+        - name: relay_0
+          type: jsk_topic_tools/Relay
+          remappings:
+            - from: ~input
+              to: input
+        - name: relay_1
+          type: jsk_topic_tools/Relay
+          remappings:
+            - from: ~input
+              to: relay_0/output
+        - name: relay_2
+          type: jsk_topic_tools/Relay
+          remappings:
+            - from: ~input
+              to: relay_1/output
+    </rosparam>
+  </node>
+</launch>

--- a/jsk_topic_tools/src/standalone_complexed_nodelet.cpp
+++ b/jsk_topic_tools/src/standalone_complexed_nodelet.cpp
@@ -1,0 +1,149 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2015, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <nodelet/loader.h>
+#include "jsk_topic_tools/rosparam_utils.h"
+#include "jsk_topic_tools/log_utils.h"
+// Parameter structure is
+// nodelets:
+//   -  name: node_name
+//      type: nodelet_type
+//      remappings:
+//        - from: from_topic
+//        - to: to_topic
+//        - from: from_topic
+//        - to: to_topic
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "standalone_complexed_nodelet");
+  ros::NodeHandle private_nh("~");
+  ros::NodeHandle nh;
+  nodelet::Loader manager(false); // Don't bring up the manager ROS API
+  nodelet::V_string my_argv;  
+  XmlRpc::XmlRpcValue nodelets_params;
+  if (private_nh.hasParam("nodelets")) {
+    XmlRpc::XmlRpcValue nodelets_values;
+    private_nh.param("nodelets", nodelets_values, nodelets_values);
+    if (nodelets_values.getType() == XmlRpc::XmlRpcValue::TypeArray) {
+      for (size_t i_nodelet = 0; i_nodelet < nodelets_values.size(); i_nodelet++) {
+        JSK_ROS_INFO("i_nodelet %lu", i_nodelet);
+        XmlRpc::XmlRpcValue onenodelet_param = nodelets_values[i_nodelet];
+        if (onenodelet_param.getType() == XmlRpc::XmlRpcValue::TypeStruct) {
+          std::string name, type;
+          nodelet::M_string remappings;
+          if (onenodelet_param.hasMember("name")) {
+            name = nh.resolveName((std::string)onenodelet_param["name"]);
+          }
+          else {
+            JSK_ROS_FATAL("element ~nodelets should have name field");
+            return 1;
+          }
+          if (onenodelet_param.hasMember("type")) {
+            type = (std::string)onenodelet_param["type"];
+          }
+          else {
+            JSK_ROS_FATAL("element ~nodelets should have type field");
+            return 1;
+          }
+          if (onenodelet_param.hasMember("remappings")) {
+            XmlRpc::XmlRpcValue remappings_params
+              = onenodelet_param["remappings"];
+            if (remappings_params.getType() == XmlRpc::XmlRpcValue::TypeArray) {
+              for (size_t remappings_i = 0; remappings_i < remappings_params.size(); remappings_i++) {
+                XmlRpc::XmlRpcValue remapping_element_param = remappings_params[remappings_i];
+                if (remapping_element_param.getType() == XmlRpc::XmlRpcValue::TypeStruct) {
+                  if (remapping_element_param.hasMember("from") && remapping_element_param.hasMember("to")) {
+                    std::string from = (std::string)remapping_element_param["from"];
+                    std::string to = (std::string)remapping_element_param["to"];
+                    if (from.size() > 0 && from[0] == '~') {
+                      ros::NodeHandle nodelet_private_nh(name);
+                      from = nodelet_private_nh.resolveName(from.substr(1, from.size() - 1));
+                    }
+                    if (to.size() > 0 && to[0] == '~') {
+                      ros::NodeHandle nodelet_private_nh(name);
+                      to = nodelet_private_nh.resolveName(to.substr(1, to.size() - 1));
+                    }
+                    else {
+                      to = nh.resolveName(to);
+                    }
+                    JSK_ROS_INFO("remapping: %s => %s", from.c_str(), to.c_str());
+                    remappings[from] = to;
+                  }
+                  else {
+                    JSK_ROS_FATAL("remappings parameter requires from and to fields");
+                    return 1;
+                  }
+                }
+                else {
+                  JSK_ROS_FATAL("remappings should be an array");
+                  return 1;
+                }
+              }
+            }
+            else {
+              JSK_ROS_FATAL("remappings should be an array");
+              return 1;
+            }
+          }
+          // Done reading parmaeter for one nodelet
+          
+          if (!manager.load(name, type, remappings, my_argv)) {
+            JSK_ROS_ERROR("Failed to load nodelet [%s -- %s]", name.c_str(), type.c_str());
+          }
+          else {
+            JSK_ROS_INFO("Succeeded to load nodelet [%s -- %s]", name.c_str(), type.c_str());
+          }
+        }
+        else {
+          JSK_ROS_FATAL("element ~nodelets should be a dictionay");
+          return 1;
+        }
+      }
+    }
+    else {
+      JSK_ROS_FATAL("~nodelets should be a list");
+      return 1;
+    }
+  }
+  JSK_ROS_INFO("done reading parmaeters");
+  std::vector<std::string> loaded_nodelets = manager.listLoadedNodelets();
+  JSK_ROS_INFO("loaded nodelets: %lu", loaded_nodelets.size());
+  for (size_t i = 0; i < loaded_nodelets.size(); i++) {
+    JSK_ROS_INFO("loaded nodelet: %s", loaded_nodelets[i].c_str());
+  }
+  ros::spin();
+  return 0;
+}


### PR DESCRIPTION
It reads nodelet clients from rosparam and launch them. It is a general
model for nodelet like stereo_image_proc. It does not need different
processes for manager/clients.

sample: standalone_complexed_nodelet_sample.launch

Format of the rosparameter is:
```yaml
      nodelets:
        - name: relay_0
          type: jsk_topic_tools/Relay
          remappings:
            - from: ~input
              to: input
        - name: relay_1
          type: jsk_topic_tools/Relay
          remappings:
            - from: ~input
              to: relay_0/output
        - name: relay_2
          type: jsk_topic_tools/Relay
          remappings:
            - from: ~input
              to: relay_1/output
```