### PR TITLE
[jsk_network_tools] Add C++ implementation of silverhammer_highspeed_receiver.

### DIFF
--- a/jsk_network_tools/CMakeLists.txt
+++ b/jsk_network_tools/CMakeLists.txt
@@ -3,7 +3,7 @@ project(jsk_network_tools)
 
 find_package(catkin REQUIRED COMPONENTS
   message_generation std_msgs sensor_msgs rostest
-  dynamic_reconfigure)
+  dynamic_reconfigure roscpp)
 catkin_python_setup()
 add_message_files(
   DIRECTORY msg
@@ -16,6 +16,7 @@ add_message_files(
   FC2OCSLargeData.msg
   OpenNISample.msg
   AllTypeTest.msg
+  SilverhammerInternalBuffer.msg
 )
 add_service_files(
   FILES
@@ -37,6 +38,13 @@ catkin_package(
 #  CATKIN_DEPENDS other_catkin_pkg
 #  DEPENDS system_lib
 )
+add_definitions("-O2")
+include_directories(include ${catkin_INCLUDE_DIRS})
+link_libraries(${catkin_LIBRARIES})
+add_executable(silverhammer_highspeed_internal_receiver
+  src/silverhammer_highspeed_internal_receiver.cpp)
+add_dependencies(silverhammer_highspeed_internal_receiver
+  ${PROJECT_NAME}_gencpp ${PROJECT_NAME}_gencfg)
 
 add_rostest(test/test_all_type_low_speed.test)
 
@@ -45,3 +53,7 @@ install(DIRECTORY scripts
   ${CATKIN_PACKAGE_SHARE_DESTINATION}
   USE_SOURCE_PERMISSIONS
   )
+install(TARGETS silverhammer_highspeed_internal_receiver
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})

--- a/jsk_network_tools/launch/simple_silverhammer_internal_buffer_openni_sample.launch
+++ b/jsk_network_tools/launch/simple_silverhammer_internal_buffer_openni_sample.launch
@@ -1,0 +1,32 @@
+<launch>
+  <include file="$(find openni2_launch)/launch/openni2.launch">
+    <arg name="depth_registration" value="true" />
+  </include>
+  <node pkg="jsk_network_tools" type="silverhammer_highspeed_streamer.py"
+        output="screen"
+        name="streamer">
+    <rosparam>
+      message: jsk_network_tools/OpenNISample
+    </rosparam>
+  </node>
+  <node pkg="jsk_network_tools" type="silverhammer_highspeed_receiver_with_internal_buffer.py"
+        output="screen"
+        name="receiver">
+    <rosparam>
+      message: jsk_network_tools/OpenNISample
+      topic_prefix: relayed
+      expected_rate: 2
+    </rosparam>
+  </node>
+  <group ns="receiver">
+    <node pkg="jsk_network_tools" type="silverhammer_highspeed_internal_receiver"
+          name="internal_receiver">
+    </node>
+  </group>
+  <node pkg="image_view" type="image_view" name="original_image">
+    <remap from="image" to="/camera/rgb/image_rect_color" />
+  </node>
+  <node pkg="image_view" type="image_view" name="relayed_image">
+    <remap from="image" to="/relayed/camera/rgb/image_rect_color" />
+  </node>
+</launch>

--- a/jsk_network_tools/msg/SilverhammerInternalBuffer.msg
+++ b/jsk_network_tools/msg/SilverhammerInternalBuffer.msg
@@ -1,0 +1,3 @@
+Header header
+uint32 seq_id
+uint8[] data

--- a/jsk_network_tools/scripts/silverhammer_highspeed_receiver_with_internal_buffer.py
+++ b/jsk_network_tools/scripts/silverhammer_highspeed_receiver_with_internal_buffer.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+
+import rospy
+from jsk_network_tools.msg import FC2OCSLargeData, SilverhammerInternalBuffer
+from jsk_network_tools.silverhammer_util import *
+from threading import Lock
+from StringIO import StringIO
+from std_msgs.msg import Time
+from io import BytesIO
+from socket import *
+from struct import pack
+import diagnostic_updater
+from diagnostic_msgs.msg import DiagnosticStatus
+import roslib
+from roslib.message import get_message_class
+
+#ifdef USE_THREAD
+# from threading import Thread
+# from Queue import Queue
+#else
+from multiprocessing import Process, Queue
+#endif
+
+class SilverHammerReceiver:
+    def __init__(self):
+        message_class_str = rospy.get_param("~message", 
+                                            "jsk_network_tools/FC2OCSLargeData")
+        try:
+            self.message_class = get_message_class(message_class_str)
+        except:
+            raise Exception("invalid topic type: %s"%message_class_str)
+        self.lock = Lock()
+        self.diagnostic_updater = diagnostic_updater.Updater()
+        self.diagnostic_updater.setHardwareID("none")
+        self.diagnostic_updater.add("HighspeedReceiver", self.diagnosticCallback)
+        self.latch = rospy.get_param("~latch", True)
+        self.pesimistic = rospy.get_param("~pesimistic", False)
+        self.fragment_packets_torelance = rospy.get_param("~fragment_packets_torelance", 20)
+        self.timestamp_overwrite_topics = rospy.get_param("~timestamp_overwrite_topics", [])
+        self.publish_only_if_updated_topics = rospy.get_param("~publish_only_if_updated_topics", [])
+        self.prev_seq_ids = {}
+        self.receive_port = rospy.get_param("~receive_port", 16484)
+        self.receive_ip = rospy.get_param("~receive_ip", "localhost")
+        self.topic_prefix = rospy.get_param("~topic_prefix", "/from_fc")
+        if not self.topic_prefix.startswith("/"):
+            self.topic_prefix = "/" + self.topic_prefix
+        if self.topic_prefix == "/":
+            self.topic_prefix = ""
+        self.publishers = publishersFromMessage(self.message_class,
+                                                self.topic_prefix, 
+                                                latch=self.latch)
+        self.packet_size = rospy.get_param("~packet_size", 1400)   #2Hz
+        self.launched_time = rospy.Time.now()
+        self.last_received_time = rospy.Time(0)
+        self.last_received_time_pub = rospy.Publisher("~last_received_time", Time)
+        self.last_published_seq_id = -1
+        self.diagnostic_timer = rospy.Timer(rospy.Duration(1.0 / 10),
+                                            self.diagnosticTimerCallback)
+        self.packets_queue = Queue()
+    def diagnosticCallback(self, stat):
+        # always OK
+        stat.summary(DiagnosticStatus.OK, "OK")
+        with self.lock:
+            now = rospy.Time.now()
+            stat.add("Uptime [sec]",
+                     (now - self.launched_time).to_sec())
+            stat.add("Time from last input [sec]", 
+                     (now - self.last_received_time).to_sec())
+            stat.add("UDP address", self.receive_ip)
+            stat.add("UDP port", self.receive_port)
+        return stat
+    def diagnosticTimerCallback(self, event):
+        self.diagnostic_updater.update()
+        with self.lock:
+            self.last_received_time_pub.publish(self.last_received_time)
+    def run(self):
+        sub = rospy.Subscriber("~input", SilverhammerInternalBuffer, self.callback)
+        rospy.spin()
+    def callback(self, msg):
+        b = StringIO()
+        b.write(msg.data)
+        deserialized_data = []
+        rospy.msg.deserialize_messages(b, deserialized_data,
+                                       self.message_class)
+        rospy.loginfo("received %d message" % len(deserialized_data))
+        if len(deserialized_data) > 0:
+            # publish data
+            msg = deserialized_data[0]
+            messages = decomposeLargeMessage(msg, self.topic_prefix)
+            now = rospy.Time.now()
+            for pub in self.publishers:
+                if pub.name in messages:
+                    if not pub.name in self.publish_only_if_updated_topics:
+                        rospy.loginfo("publishing %s" % pub.name)
+                        if pub.name in self.timestamp_overwrite_topics:
+                            if (hasattr(messages[pub.name], "header") and
+                                hasattr(messages[pub.name].header, "stamp")):
+                                messages[pub.name].header.stamp = now
+                        pub.publish(messages[pub.name])
+                    #pub.publish(messages[pub.name])
+                else:
+                    rospy.logwarn("""cannot find '%s' in deserialized messages %s""" % (pub.name, messages.keys()))
+            synchronized_publishers = []
+            at_lest_one_topic = False
+            # Check if there is any topic to update
+            for pub in self.publishers:
+                if pub.name in messages:
+                    if pub.name in self.publish_only_if_updated_topics:
+                        synchronized_publishers.append(pub)
+                        if (hasattr(messages[pub.name], "header") and
+                            hasattr(messages[pub.name].header, "stamp")):
+                            messages[pub.name].header.stamp = now # Overwrite with the same timestamp
+                        if (hasattr(messages[pub.name], "header") and
+                            hasattr(messages[pub.name].header, "seq")):
+                            # Skip rule
+                            if (pub.name in self.prev_seq_ids.keys() and 
+                                messages[pub.name].header.seq == self.prev_seq_ids[pub.name]):
+                                rospy.loginfo("skip publishing %s " % (pub.name))
+                                pass
+                            else:
+                                rospy.loginfo("messages[%s].header.seq: %d"% (pub.name,
+                                                                              messages[pub.name].header.seq))
+                                rospy.loginfo("self.prev_seq_ids[%s]: %d"  % (pub.name,
+                                                                              messages[pub.name].header.seq))
+                                self.prev_seq_ids[pub.name] = messages[pub.name].header.seq
+                                at_lest_one_topic = True
+            if at_lest_one_topic:
+                for pub in synchronized_publishers:
+                    pub.publish(messages[pub.name])
+        else:
+            rospy.logerr("missed some packets")
+
+
+if __name__ == "__main__":
+    rospy.init_node("silverhammer_highspeed_receiver")
+    receiver = SilverHammerReceiver()
+    receiver.run()

--- a/jsk_network_tools/src/silverhammer_highspeed_internal_receiver.cpp
+++ b/jsk_network_tools/src/silverhammer_highspeed_internal_receiver.cpp
@@ -1,0 +1,231 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <iostream>
+#include <boost/array.hpp>
+#include <boost/asio.hpp>
+#include <boost/thread.hpp>
+#include <jsk_network_tools/SilverhammerInternalBuffer.h>
+#include <ros/ros.h>
+#include <boost/shared_ptr.hpp>
+#include <algorithm>
+
+namespace jsk_network_tools
+{
+  typedef unsigned char Base;
+  //typedef char Base;
+  class Packet
+  {
+  public:
+    typedef boost::shared_ptr<Packet> Ptr;
+    size_t seq_id;
+    size_t packet_id;
+    size_t packet_num;
+    std::vector<Base> data;
+    Packet(size_t aseq_id, size_t apacket_id, size_t apacket_num):
+      seq_id(aseq_id), packet_id(apacket_id), packet_num(apacket_num)
+    {
+    }
+
+    void fillData(size_t size, Base* buf)
+    {
+      data.resize(size);
+      memcpy(&data[0], &buf[12], size);
+    }
+
+    void fill(std::vector<Base>& target, size_t start, size_t end)
+    {
+      memcpy(&target[start], &data[0], end - start);
+    }
+
+    bool operator<(const Packet& other) const
+    {
+      return packet_id < other.packet_id;
+    }
+  };
+
+  class SilverhammerHighspeedInternalReceiver
+  {
+  public:
+    typedef std::vector<Packet> PacketArray;
+    typedef std::map<size_t, PacketArray> PacketTable;
+    SilverhammerHighspeedInternalReceiver(): initialized_(false)
+    {
+      ros::NodeHandle nh, pnh("~");
+      nh.param("receive_port", receive_port_, 16484);
+      nh.param("pesimistic", pesimistic_, true);
+      nh.param("fragment_packets_tolerance", fragment_packets_tolerance_, 0);
+      nh.param("expected_rate", expected_rate_, 2.0);
+      pub_ = nh.advertise<SilverhammerInternalBuffer>("input", 1);
+      // nh.param("packet_size", packet_size_, 1400);
+      boost::asio::io_service io_service;
+      socket_.reset(new boost::asio::ip::udp::socket(io_service, boost::asio::ip::udp::endpoint(boost::asio::ip::udp::v4(), receive_port_)));
+      thread_ = boost::thread(boost::bind(&SilverhammerHighspeedInternalReceiver::threadFunc, this));
+      pub_thread_ = boost::thread(boost::bind(&SilverhammerHighspeedInternalReceiver::publishPacketsFunc, this));
+      
+    }
+
+  protected:
+
+    void threadFunc()
+    {
+      PacketArray packet_array;
+      // Is it fast enough?
+      int last_received_seq_id = -1;
+      while (ros::ok()) {
+        boost::array<Base, 1500> recv_buf; // only support 1500 MTU (without header)
+        boost::asio::ip::udp::endpoint remote_endpoint;
+        boost::system::error_code error;
+        size_t len = socket_->receive_from(boost::asio::buffer(recv_buf), remote_endpoint, 0, error);
+        //ROS_INFO("received packet (%lu bytes = %lu bits)", len, len * 8);
+        if (len < 4 + 4 + 4) {
+          ROS_WARN("too short packet");
+          continue;
+        }
+        size_t seq_id = recv_buf[0] * (1 << 24) + recv_buf[1] * (1 << 16) + recv_buf[2] * (1 << 8) + recv_buf[3] * (1 << 0);
+        size_t packet_id = recv_buf[0 + 4] * (1 << 24) + recv_buf[1 + 4] * (1 << 16) + recv_buf[2 + 4] * (1 << 8) + recv_buf[3 + 4] * (1 << 0);
+        size_t packet_num = recv_buf[0 + 8] * (1 << 24) + recv_buf[1 + 8] * (1 << 16) + recv_buf[2 + 8] * (1 << 8) + recv_buf[3 + 8] * (1 << 0);
+        
+        Packet packet(seq_id, packet_id, packet_num);
+        packet.fillData(len - 4 * 3, recv_buf.data());
+        // ROS_INFO("seq_id := %lu", seq_id);
+        //ROS_INFO("packet_id := %lu", packet_id);
+        // ROS_INFO("packet_num := %lu", packet_num);
+
+        if (last_received_seq_id == -1) {
+          packet_array.push_back(packet);
+        }
+        else if (last_received_seq_id != seq_id) {
+          ROS_INFO("seq_id := %lu, packet_array.size() := %lu, packet_num := %lu",
+                   last_received_seq_id, packet_array.size(), packet_array[0].packet_num);
+          size_t before_size = packet_array.size();
+          if (packet_array.size() == packet_array[0].packet_num || !pesimistic_) {
+            boost::mutex::scoped_lock lock(shared_packet_mutex_);
+            shared_packet_array_ = packet_array;
+            // Exit from special section as soon as possible
+          }
+          packet_array = PacketArray();
+          packet_array.reserve(before_size * 2);
+          packet_array.push_back(packet);
+        }
+        else {
+          packet_array.push_back(packet);
+        }
+        last_received_seq_id = seq_id;
+      }
+    }
+
+    void publishPacketsFunc()
+    {
+      ros::Rate r(expected_rate_);
+      int published_seq_id = -1;
+      while (ros::ok()) {
+        {
+          PacketArray publish_thread_packet_array;
+          {
+            boost::mutex::scoped_lock lock(shared_packet_mutex_);
+            if (shared_packet_array_.size() != 0) {
+              publish_thread_packet_array = shared_packet_array_;
+            }
+            // Exit from special section as soon as possible
+          }
+          if (publish_thread_packet_array.size() != 0) {
+            if (publish_thread_packet_array[0].seq_id != published_seq_id) {
+              publishPackets(publish_thread_packet_array);
+              published_seq_id = publish_thread_packet_array[0].seq_id;
+            }
+          }
+          r.sleep();
+        }
+      }
+    }
+
+    void publishPackets(PacketArray& packet_array)
+    {
+      msg_.header.stamp = ros::Time::now();
+      msg_.seq_id = packet_array[0].seq_id;
+      // Sort packet_array according to packet_id
+      std::sort(packet_array.begin(), packet_array.end());
+      // We expect all the packet size are same
+      size_t packet_size = packet_array[0].data.size();
+      size_t num = packet_array[0].packet_num;
+      if (msg_.data.size() != num * packet_size) {
+        msg_.data.resize(num * packet_size);
+      }
+      std::fill(msg_.data.begin(), msg_.data.end(), 0);
+      PacketArray::iterator it = packet_array.begin();
+      size_t target_packet_id = 0;
+      
+      ROS_INFO("expected data size: %lu", num * packet_size);
+      while (target_packet_id < num && it != packet_array.end()) {
+        if (it->packet_id == target_packet_id) {
+          it->fill(msg_.data, target_packet_id * packet_size, (target_packet_id + 1) * packet_size);
+          ++it;
+        }
+        else {                  // fill by dummy 0 data == just skip
+          // pass
+        }
+        ++target_packet_id;
+      }
+
+      pub_.publish(msg_);
+    }
+
+    PacketArray shared_packet_array_;
+    SilverhammerInternalBuffer msg_;
+    bool initialized_;
+    boost::mutex mutex_;
+    boost::mutex shared_packet_mutex_;
+    boost::condition_variable thread_state_;
+    boost::thread thread_;
+    boost::thread pub_thread_;
+    boost::shared_ptr<boost::asio::ip::udp::socket> socket_;
+    int receive_port_;
+    int fragment_packets_tolerance_;
+    std::string receive_ip_;
+    double expected_rate_;
+    //int packet_size_;
+    ros::Publisher pub_;
+    bool pesimistic_;
+  private:
+  };
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "silverhammer_highspeed_internal_receiver");
+  jsk_network_tools::SilverhammerHighspeedInternalReceiver receiver;
+  ros::spin();
+  return 0;
+}


### PR DESCRIPTION
Only core is implemented in c++.

It cooperates with python thin wrapper and bridged via ros between them.

* python is too slow to implement receiver in one process
  * Giant lock does not allow us to write parallel processes
* python multiprocessing may generate zombie process
  * Because python signal/exception mechanism is not robust with multiprocessing and socket programming
* Implement UDP server in C++ to write `receiving packets` and `collecting packets` in different thread for performance reason.
* But C++ is not good at Meta Object Protocol, so C++ UDP server just sends not-deserialized ROS buffer to python wrapper via normal ROS topic protocol and convert it into serialized ROS message in python, because we'd like to specify different classes from ros parameters.