### PR TITLE
Remove no need stdout in rossetip

### DIFF
--- a/jsk_tools/env-hooks/99.jsk_tools.sh
+++ b/jsk_tools/env-hooks/99.jsk_tools.sh
@@ -92,7 +92,7 @@ rossetip_addr() {
     fi
     local mask_target_ip=$(echo ${target_hostip} | cut -d. -f1-3)
     for ip in $(hostname -I); do
-        if echo $ip | egrep "^172.17.42.|^127.0."; then
+        if echo $ip | egrep "^172.17.42.|^127.0." >/dev/null; then
             # skip docker/local host
             continue
         elif [ "${mask_targetip}" = "" ]; then


### PR DESCRIPTION
**BEFORE**
```
set ROS_MASTER_URI to http://pr1012.jsk.imi.i.u-tokyo.ac.jp:11311
172.17.42.1
set ROS_IP and ROS_HOSTNAME to 10.68.0.100
```

**AFTER**
```
set ROS_MASTER_URI to http://pr1012.jsk.imi.i.u-tokyo.ac.jp:11311
set ROS_IP and ROS_HOSTNAME to 10.68.0.100
```