### PR TITLE
[jsk_data] Show size of files when listing remote bag files

### DIFF
--- a/jsk_data/Makefile
+++ b/jsk_data/Makefile
@@ -12,9 +12,9 @@ large-list:
 	@echo "***\n*** Consider using KEYWORD option to get the list of large data\n***"
 	@echo "*** for example... "
 	@echo "*** > make large-list KEYWORD=2014_05*"
-	@ssh ${LOGIN_USER}@aries.jsk.t.u-tokyo.ac.jp ls /home/jsk/ros/data/large/${KEYWORD}
+	@ssh ${LOGIN_USER}@aries.jsk.t.u-tokyo.ac.jp ls -sh /home/jsk/ros/data/large/${KEYWORD}
 small-list:
-	@ssh ${LOGIN_USER}@aries.jsk.t.u-tokyo.ac.jp ls /home/jsk/ros/data/small/${KEYWORD}
+	@ssh ${LOGIN_USER}@aries.jsk.t.u-tokyo.ac.jp ls -sh /home/jsk/ros/data/small/${KEYWORD}
 
 large:
 	@echo "***\n*** Consider using KEYWORD option to download large data\n***"


### PR DESCRIPTION
https://github.com/jsk-ros-pkg/jsk_common/issues/1108

Show size of bag files as well as their names.

```
$ make small-list
total 9.1G
2.6G 2014_10_15_fridge_demo.bag
935M amt_hrp2_lie_on_stomach_2011-07-19-10-17-25.bag
 26M dinosauor.pcd
467M hrp2016-rotate-elephant-onehand-20101021.bag
432M hrp2-hand-over-object-20100610.bag
310M hrp2-raw-camera-images-for-cr-capture.bag
 22M hrp2-sample-20100619.bag
1.8M hrp2w-room602-mapping-20100415-2.bag
 97M hrp4r-walk-hat-exp-without-passer-by-2012-02-15-20-42-10.bag
220M hrp4r-walk-hat-exp-without-passer-by-2012-02-15-21-08-01.bag
182M hrp4r-walk-hat-exp-with-passer-by-2012-02-15-21-22-45.bag
228M hrp4r-walk-hat-exp-with-passer-by-2012-02-15-21-34-09.bag
 28M kago1.pcd
 38M kago2.pcd
1.1G kenzo-armarker-20111216.bag
1.4G kojiro-view-20111218.bag
 15M mikita-experiment-set.pcd
708M motegi-arpose-20111216.bag
 27M room.pcd
4.0K screenshot-1324970785.cam
 24K screenshot-1324970785.png
 12M throw_blue_ball.pcd
 26M toaster1.pcd
 18M tsuda.pcd
388M velodyne_2012_0604.bag
```