### PR TITLE
Specify version: master in rosinstall for jsk-ros-pkg/*

### DIFF
--- a/jsk.rosinstall
+++ b/jsk.rosinstall
@@ -6,48 +6,63 @@
 - git:
     uri: https://github.com/jsk-ros-pkg/openrave_planning.git
     local-name: jsk-ros-pkg/openrave_planning
+    version: master
 - git:
     uri: https://github.com/jsk-ros-pkg/jsk_visualization.git
     local-name: jsk-ros-pkg/jsk_visualization
+    version: master
 - git:
     uri: https://github.com/jsk-ros-pkg/jsk_smart_apps.git
     local-name: jsk-ros-pkg/jsk_smart_apps
+    version: master
 - git:
     uri: https://github.com/jsk-ros-pkg/jsk_roseus.git
     local-name: jsk-ros-pkg/jsk_roseus
+    version: master
 - git:
     uri: https://github.com/jsk-ros-pkg/jsk_robot.git
     local-name: jsk-ros-pkg/jsk_robot
+    version: master
 - git:
     uri: https://github.com/jsk-ros-pkg/jsk_recognition.git
     local-name: jsk-ros-pkg/jsk_recognition
+    version: master
 - git:
     uri: https://github.com/jsk-ros-pkg/jsk_pr2eus.git
     local-name: jsk-ros-pkg/jsk_pr2eus
+    version: master
 - git:
     uri: https://github.com/jsk-ros-pkg/jsk_planning.git
     local-name: jsk-ros-pkg/jsk_planning
+    version: master
 - git:
     uri: https://github.com/jsk-ros-pkg/jsk_model_tools.git
     local-name: jsk-ros-pkg/jsk_model_tools
+    version: master
 - git:
     uri: https://github.com/jsk-ros-pkg/jsk_demos.git
     local-name: jsk-ros-pkg/jsk_demos
+    version: master
 - git:
     uri: https://github.com/jsk-ros-pkg/jsk_control.git
     local-name: jsk-ros-pkg/jsk_control
+    version: master
 - git:
     uri: https://github.com/jsk-ros-pkg/jsk_common.git
     local-name: jsk-ros-pkg/jsk_common
+    version: master
 - git:
     uri: https://github.com/jsk-ros-pkg/jsk_common_msgs.git
     local-name: jsk-ros-pkg/jsk_common_msgs
+    version: master
 - git:
     uri: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
     local-name: jsk-ros-pkg/jsk_3rdparty
+    version: master
 - git:
     uri: https://github.com/jsk-ros-pkg/jsk_openni_kinect.git
     local-name: jsk-ros-pkg/jsk_openni_kinect
+    version: master
 
 # for snap map icp
 - git:


### PR DESCRIPTION
This helps to find out version divergence.

```
% wstool info jsk-ros-pkg/*
workspace: /home/wkentaro/ros/indigo/src

 Localname                     S SCM  Version-Spec UID  (Spec)                 URI  (Spec) [http(s)://...]
 ---------                     - ---- ------------ -----------                 ---------------------------
 jsk-ros-pkg/jsk_openni_kinect M git  master       eb6866982139                github.com/jsk-ros-pkg/jsk_openni_kinect.git
 jsk-ros-pkg/jsk_3rdparty        git  master       3d3ed2e4200a                github.com/jsk-ros-pkg/jsk_3rdparty.git
 jsk-ros-pkg/jsk_common_msgs     git  master       d10f85577809                github.com/jsk-ros-pkg/jsk_common_msgs.git
 jsk-ros-pkg/jsk_common        V git  master       817329cbf7b4 (3c20fefa1200) github.com/jsk-ros-pkg/jsk_common.git
 jsk-ros-pkg/jsk_control         git  master       4381dab13b19                github.com/jsk-ros-pkg/jsk_control.git
 jsk-ros-pkg/jsk_demos           git  master       d29ebbef80a0                github.com/jsk-ros-pkg/jsk_demos.git
 jsk-ros-pkg/jsk_model_tools   M git  master       fb77908f35e4                github.com/jsk-ros-pkg/jsk_model_tools.git
 jsk-ros-pkg/jsk_planning        git  master       35568fe3bcbf                github.com/jsk-ros-pkg/jsk_planning.git
 jsk-ros-pkg/jsk_pr2eus          git  master       8b9c45effd76                github.com/jsk-ros-pkg/jsk_pr2eus.git
 jsk-ros-pkg/jsk_recognition     git  master       6a83868c95fe                github.com/jsk-ros-pkg/jsk_recognition.git
 jsk-ros-pkg/jsk_robot           git  master       50f0a1ed7f56                github.com/jsk-ros-pkg/jsk_robot.git
 jsk-ros-pkg/jsk_roseus          git  master       1045589949d2                github.com/jsk-ros-pkg/jsk_roseus.git
 jsk-ros-pkg/jsk_smart_apps    M git  master       248e74ef17c1                github.com/jsk-ros-pkg/jsk_smart_apps.git
 jsk-ros-pkg/jsk_visualization   git  master       99ea7e6c929f                github.com/jsk-ros-pkg/jsk_visualization.git
 jsk-ros-pkg/openrave_planning   git  master       2da7bcc79128                github.com/jsk-ros-pkg/openrave_planning.git
% (cd jsk-ros-pkg/jsk_common; git branch)
  gitter-badge
  master
  remove-noneed-stdout-rossetip
* specify-master-in-rosinstall   # NOT 'master'!!
```