### PR TITLE
[jsk_topic_tools] Supress output messages from testing

### DIFF
--- a/jsk_topic_tools/launch/topic_buffer_client_sample.launch
+++ b/jsk_topic_tools/launch/topic_buffer_client_sample.launch
@@ -6,15 +6,16 @@
   <arg name="USE_UPDATE_RATE" default="false" />
   <arg name="UPDATE_RATE" default="1" />
   <arg name="FIXED_RATE" default="0.1" />
+  <arg name="OUTPUT" default="screen" />
 
   <node pkg="roscpp_tutorials" type="listener" name="listener"
-	output="screen">
+        output="$(arg OUTPUT)">
     <remap from="chatter" to="chatter_buffered"/>
   </node>
 
 
   <node pkg="jsk_topic_tools" type="topic_buffer_client" name="sample_topic_buffer_client"
-	output="screen">
+        output="$(arg OUTPUT)">
     <remap from="/list" to="/sample_topic_buffer_server/list"/>
     <remap from="/update" to="/sample_topic_buffer_server/update"/>
     <param name="update_rate" value="$(arg UPDATE_RATE)" if="$(arg USE_UPDATE_RATE)"  />

--- a/jsk_topic_tools/launch/topic_buffer_server_sample.launch
+++ b/jsk_topic_tools/launch/topic_buffer_server_sample.launch
@@ -1,11 +1,11 @@
 <launch>
   <arg name="USE_PERIODIC_RATE" default="false" />
   <arg name="PERIODIC_RATE" default="1" />
-
-  <node pkg="roscpp_tutorials" type="talker" name="talker" output="screen"/>
+  <arg name="OUTPUT" default="screen" />
+  <node pkg="roscpp_tutorials" type="talker" name="talker" output="$(arg OUTPUT)"/>
 
   <node pkg="jsk_topic_tools" type="topic_buffer_server" name="sample_topic_buffer_server"
-	args="/chatter"	output="screen" >
+        args="/chatter"	output="$(arg OUTPUT)" >
     <param name="periodic_rate" value="$(arg PERIODIC_RATE)" if="$(arg USE_PERIODIC_RATE)"  />
   </node>
 

--- a/jsk_topic_tools/test/test_hz_measure.py
+++ b/jsk_topic_tools/test/test_hz_measure.py
@@ -35,19 +35,17 @@ class TestHzMeasure(unittest.TestCase):
         while hz_msg == None:
             rospy.loginfo('wait for msg...')
             if not rospy.is_shutdown():
-                rospy.sleep(1.0)          #wait 1 sec
+                rospy.sleep(5.0)          #wait for 5 sec
         # should be 30Hz
         msgs = []
         while len(msgs) < 30:
             msgs.append(hz_msg.data)
-            rospy.loginfo('hz of msg %s'%hz_msg.data)
+            # rospy.loginfo('hz of msg %s'%hz_msg.data)
             rospy.sleep(0.1)
         hz = np.median(msgs)
         rospy.loginfo('average hz of msg %s'%np.mean(msgs))
         rospy.loginfo('median  hz of msg %s'%hz)
-        self.assertTrue(eps_equal(hz,
-                                  30,
-                                  1))
+        self.assertTrue(eps_equal(hz, 30, 1))
 
 if __name__ == "__main__":
     import rostest

--- a/jsk_topic_tools/test/test_topic_buffer.test
+++ b/jsk_topic_tools/test/test_topic_buffer.test
@@ -1,6 +1,10 @@
 <launch>
-  <include file="$(find jsk_topic_tools)/launch/topic_buffer_client_sample.launch" />
-  <include file="$(find jsk_topic_tools)/launch/topic_buffer_server_sample.launch" />
+  <include file="$(find jsk_topic_tools)/launch/topic_buffer_client_sample.launch">
+    <arg name="OUTPUT" value="log" />
+  </include>
+  <include file="$(find jsk_topic_tools)/launch/topic_buffer_server_sample.launch">
+    <arg name="OUTPUT" value="log" />
+  </include>
 
   <param name="hztest_chatter/topic" value="chatter" />
   <param name="hztest_chatter/hz" value="10.0" />

--- a/jsk_topic_tools/test/test_topic_buffer_close_wait.test
+++ b/jsk_topic_tools/test/test_topic_buffer_close_wait.test
@@ -3,16 +3,16 @@
   <node pkg="roscpp_tutorials" type="talker" name="talker"/>
 
   <node pkg="jsk_topic_tools" type="topic_buffer_server" name="sample_topic_buffer_server"
-	args="/chatter"	output="screen" respawn="true" />
+        args="/chatter"	output="log" respawn="true" />
 
   <node pkg="roscpp_tutorials" type="listener" name="listener"
-	output="screen">
+        output="log">
     <remap from="chatter" to="chatter_buffered"/>
   </node>
 
 
   <node pkg="jsk_topic_tools" type="topic_buffer_client" name="sample_topic_buffer_client"
-	output="screen" respawn="true" >
+        output="log" respawn="true" >
     <remap from="/list" to="/sample_topic_buffer_server/list"/>
     <remap from="/update" to="/sample_topic_buffer_server/update"/>
     <param name="update_rate" value="0.1" />

--- a/jsk_topic_tools/test/test_topic_buffer_fixed_rate.test
+++ b/jsk_topic_tools/test/test_topic_buffer_fixed_rate.test
@@ -1,8 +1,11 @@
 <launch>
   <include file="$(find jsk_topic_tools)/launch/topic_buffer_client_sample.launch" >
     <arg name="USE_FIXED_RATE" value="true" />
+    <arg name="OUTPUT" value="log" />
   </include>
-  <include file="$(find jsk_topic_tools)/launch/topic_buffer_server_sample.launch" />
+  <include file="$(find jsk_topic_tools)/launch/topic_buffer_server_sample.launch">
+    <arg name="OUTPUT" value="log" />
+  </include>
 
   <param name="hztest_chatter/topic" value="chatter" />
   <param name="hztest_chatter/hz" value="10.0" />

--- a/jsk_topic_tools/test/test_topic_buffer_fixed_rate_and_update_rate.test
+++ b/jsk_topic_tools/test/test_topic_buffer_fixed_rate_and_update_rate.test
@@ -2,8 +2,11 @@
   <include file="$(find jsk_topic_tools)/launch/topic_buffer_client_sample.launch" >
     <arg name="USE_FIXED_RATE" value="true" />
     <arg name="USE_UPDATE_RATE" value="1" />
+    <arg name="OUTPUT" value="log" />
   </include>
-  <include file="$(find jsk_topic_tools)/launch/topic_buffer_server_sample.launch" />
+  <include file="$(find jsk_topic_tools)/launch/topic_buffer_server_sample.launch">
+    <arg name="OUTPUT" value="log" />
+  </include>
 
   <param name="hztest_chatter/topic" value="chatter" />
   <param name="hztest_chatter/hz" value="10.0" />

--- a/jsk_topic_tools/test/test_topic_buffer_update_rate.test
+++ b/jsk_topic_tools/test/test_topic_buffer_update_rate.test
@@ -1,8 +1,11 @@
 <launch>
   <include file="$(find jsk_topic_tools)/launch/topic_buffer_client_sample.launch" >
     <arg name="USE_UPDATE_RATE" value="1" />
+    <arg name="OUTPUT" value="log" />
   </include>
-  <include file="$(find jsk_topic_tools)/launch/topic_buffer_server_sample.launch" />
+  <include file="$(find jsk_topic_tools)/launch/topic_buffer_server_sample.launch">
+    <arg name="OUTPUT" value="log" />
+  </include>
 
   <param name="hztest_chatter/topic" value="chatter" />
   <param name="hztest_chatter/hz" value="10.0" />


### PR DESCRIPTION
It's difficult to say whether this change is good or not, but these tests are now stable and we can ignore debug-helpful messages