### PR TITLE
Add document how to install scudcloud on 12.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,17 @@ Restart docker from slack
 
 Type `restart docker` from slack#travis channel.
 
+Use [scudcloud](https://github.com/raelgc/scudcloud) on 12.04
+-------------------------------------------------------------
+ScudCloud is a client of slack.
+You can install it on 12.04 by following ppas
+```
+sudo add-apt-repository -y ppa:gstreamer-developers/ppa
+sudo add-apt-repository -y ppa:immerrr-k/qtwebkit4-backport
+sudo apt-add-repository -y ppa:rael-gc/scudcloud
+sudo apt-get install scudcloud
+```
+
 Deb Build Status
 -----------------
 


### PR DESCRIPTION
scudcloud is a desktop client of slack.
You can use it on 14.04 without no effort but on 12.04 we need ppas.

![screenshot from 2015-09-17 18 03 37](https://cloud.githubusercontent.com/assets/40454/9929242/716f83dc-5d66-11e5-969e-8333cbf85393.png)
