### PR TITLE
[jsk_topic_tools] Warning for no connection in ConnectionBasedNodelet

### DIFF
--- a/jsk_topic_tools/include/jsk_topic_tools/connection_based_nodelet.h
+++ b/jsk_topic_tools/include/jsk_topic_tools/connection_based_nodelet.h
@@ -91,6 +91,12 @@ namespace jsk_topic_tools
     virtual void connectionCallback(const ros::SingleSubscriberPublisher& pub);
 
     /** @brief
+     * callback function which is called when walltimer
+     * duration run out.
+     */
+    virtual void warnNeverSubscribedCallback(const ros::WallTimerEvent& event);
+
+    /** @brief
      * This method is called when publisher is subscribed by other
      * nodes. 
      * Set up subscribers in this method.
@@ -159,10 +165,21 @@ namespace jsk_topic_tools
     boost::shared_ptr<ros::NodeHandle> pnh_;
 
     /** @brief
+     * WallTimer instance for warning about no connection.
+     */
+    ros::WallTimer timer_;
+
+    /** @brief
      * A flag to check if any publisher is already subscribed
      * or not.
      */
     bool subscribed_;
+
+    /** @brief
+     * A flag to check if the node has been ever subscribed
+     * or not.
+     */
+    bool ever_subscribed_;
 
     /** @brief
      * A flag to disable watching mechanism and always subscribe input 


### PR DESCRIPTION
For #1132 

```
% rosrun jsk_topic_tools string_relay
[ INFO] [1443503176.478853037]: Initializing nodelet with 8 worker threads.
[ INFO] [1443503176.521582239]: ack1
[ INFO] [1443503176.521756137]: ack2
```

it won't enter the wallTimerCallback method, do you have any idea about this?
(no ack3 and ack4)