### PR TITLE
[jsk_data] Estimate filename if longer than 40

### DIFF
--- a/jsk_data/src/jsk_data/cli.py
+++ b/jsk_data/src/jsk_data/cli.py
@@ -142,6 +142,9 @@ def cmd_pubinfo(filename, show_dl_cmd):
         stdout.next()  # drop header
         for line in stdout.readlines():
             file_id, title = line.split()[:2]
+            # FIXME: gdrive does not return full title if it is longer than 40
+            if len(filename) > 40:
+                filename = filename[:19] + '...' + filename[-18:]
             if filename == title:
                 break
         else:


### PR DESCRIPTION
Because gdrive does not return full title if it is longer than 40

Closes #1155