### PR TITLE
Hide warning output from lsof because of user problem.

### DIFF
--- a/jsk_tools/src/jsk_tools/sanity_lib.py
+++ b/jsk_tools/src/jsk_tools/sanity_lib.py
@@ -247,7 +247,7 @@ def checkUSBExist(vendor_id, product_id, expect_usb_nums = 1, host="", success_m
 def getROSMasterCLOSE_WAIT(host, username=""):
     if username != "":
         host = username + "@" + host
-    return int(subprocess.check_output(["ssh", host, "sudo", "bash", "-c", '"lsof -l | grep rosmaster | grep CLOSE_WAIT | wc -l"']).split("\n")[0])
+    return int(subprocess.check_output(["ssh", host, "sudo", "bash", "-c", '"lsof -l 2>/dev/null | grep rosmaster | grep CLOSE_WAIT | wc -l"']).split("\n")[0])
 
 def checkROSMasterCLOSE_WAIT(host, username=""):
     try:


### PR DESCRIPTION
When `sudo lsof -l` is called, 
```
lsof: WARNING: can't stat() fuse.gvfs-fuse-daemon file system /home/hrpuser/.gvfs
      Output information may be incomplete.
```
occurs.

This is because root user cannot access other user fuse system:
http://unix.stackexchange.com/questions/171519/lsof-warning-cant-stat-fuse-gvfsd-fuse-file-system

One solution is set `allow_root` in /etc/fuse.conf, but it seems to have too large influences.

So I hide this warning message by redirecting.

@garaemon , how about this?
