### PR TITLE
[jsk_tools] Add kill_after_seconds.py. It will kill a process after specified seconds. It is useful to handle roslaunch for benchmarking.

### DIFF
--- a/jsk_tools/bin/kill_after_seconds.py
+++ b/jsk_tools/bin/kill_after_seconds.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+from subprocess import Popen
+import sys
+import signal
+import os
+from time import sleep
+sleep_time = int(sys.argv[1])
+commands = sys.argv[2:]
+print commands
+
+p = Popen(commands)
+sleep(sleep_time)
+os.kill(p.pid, signal.SIGINT)


### PR DESCRIPTION
for example, this script benchmark effect of the number of particle:
```sh
#!/bin/sh
set -e
echo "particle,time,ang_err,dis_err" > result_particle_num.csv
for d in $(seq 10 100 5000)
do
    rosparam set /particle_filter_tracker/max_particle_num $d
    python kill_after_seconds.py 30 roslaunch tracking.launch voxel_grid_leaf_size:=0.02 octree_resolution:=0.01 &
    rostopic echo /particle_filter_tracker/output/latest_time -n 1
    sleep 5
    echo -n "$d," >> result_particle_num.csv
    time=$(rostopic echo /particle_filter_tracker/output/average_time/data -n 1 | head -n 1)
    ang=$(rostopic echo /particle_filter_tracker/output/rms_angle_error/data -n 1 | head -n 1)
    dis=$(rostopic echo /particle_filter_tracker/output/rms_distance_error/data -n 1 | head -n 1)
    echo "$time,$ang,$dis" >> result_particle_num.csv
    for job in $(jobs -p)
    do
        wait $job
    done
done

```