### PR TITLE
[jsk_tools] git-jsk-commit as git's subcommand

### DIFF
--- a/jsk_tools/CMakeLists.txt
+++ b/jsk_tools/CMakeLists.txt
@@ -23,7 +23,7 @@ install(DIRECTORY bin/
   USE_SOURCE_PERMISSIONS
   )
 
-set(BIN_EXECUTABLES ros_console.py run_tmux)
+set(BIN_EXECUTABLES git-jsk-commit ros_console.py run_tmux)
 foreach(exec ${BIN_EXECUTABLES})
   add_custom_command(OUTPUT ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_BIN_DESTINATION}/${exec}
     COMMAND cmake -E make_directory ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_BIN_DESTINATION}

--- a/jsk_tools/bin/git-jsk-commit
+++ b/jsk_tools/bin/git-jsk-commit
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+_in_what_ros_pkg () {
+  looking_path=$(pwd)
+  found=$(find $looking_path -maxdepth 1 -iname package.xml | wc -l)
+  while [ $found -eq 0 ]; do
+    looking_path=$(dirname $looking_path)
+    [ "$looking_path" = "/" ] && return
+    found=$(find $looking_path -maxdepth 1 -iname package.xml | wc -l)
+  done
+  echo $(basename $looking_path)
+}
+
+git_jsk_commit () {
+  tmp_file=$(mktemp -t XXXXX)
+  changed=$(git status --porcelain | grep '^M' | awk '{printf "\t %s\n", $2}')
+  echo "[$(_in_what_ros_pkg)] \n\nModified:\n${changed}" > ${tmp_file}
+  git commit --verbose --template ${tmp_file} $@
+}
+
+git_jsk_commit $@

--- a/jsk_tools/env-hooks/99.jsk_tools.sh
+++ b/jsk_tools/env-hooks/99.jsk_tools.sh
@@ -206,21 +206,3 @@ rosrecord () {
     return 1
   fi
 }
-
-
-_jsk_tools_what_ros_pkg () {
-  looking_path=$(pwd)
-  found=$(find $looking_path -maxdepth 1 -iname package.xml | wc -l)
-  while [ $found -eq 0 ]; do
-    looking_path=$(dirname $looking_path)
-    [ "$looking_path" = "/" ] && return
-    found=$(find $looking_path -maxdepth 1 -iname package.xml | wc -l)
-  done
-  echo $(basename $looking_path)
-}
-jsk_git_commit_verbose () {
-  tmp_file=$(mktemp -t XXXXX)
-  changed=$(git status --porcelain | grep '^M' | awk '{printf "\t %s\n", $2}')
-  echo "[$(_jsk_tools_what_ros_pkg)] \n\nModified:\n${changed}" > ${tmp_file}
-  git commit --verbose --template ${tmp_file}
-}


### PR DESCRIPTION
Usage:

```
git jsk-commit -a
```

Modified:
	 jsk_tools/CMakeLists.txt
	 jsk_tools/env-hooks/99.jsk_tools.sh