### PR TITLE
[jsk_tools] Use jsk-commit for git alias like 'commit-ueda'.

### DIFF
--- a/jsk_tools/bin/git-jsk-commit
+++ b/jsk_tools/bin/git-jsk-commit
@@ -26,7 +26,7 @@ git_jsk_commit () {
     pkg="[${pkg}] "
   fi
   echo "${pkg}\n\n${changed}\n${added}" > ${tmp_file}
-  git commit --verbose --template ${tmp_file} $@
+  git commit --verbose --template ${tmp_file} "$*"
 }
 
 git_jsk_commit $@

--- a/jsk_tools/src/git_commit_alias.py
+++ b/jsk_tools/src/git_commit_alias.py
@@ -22,7 +22,7 @@ for page in result:
             if len(alias_name.split(" ")) > 0:
                 alias_name = name.split(" ")[-1]
             alias_command = "commit-%s" % alias_name.lower()
-            alias = "commit --author='%s <%s>'" % (name, email)
+            alias = "jsk-commit --author='%s <%s>'" % (name, email)
             subprocess.check_call(["git", "config", "--global", 
                                    "alias.%s" % alias_command,
                                    alias])


### PR DESCRIPTION
* Use "$@" in jsk-commit to keep quotes across shell script.
* Use jsk-commit command for commit-ueda, commit-mmurooka and so on

Modified:
	 jsk_tools/bin/git-jsk-commit
	 jsk_tools/src/git_commit_alias.py