### PR TITLE
[jsk_topic_tools] Return to avoid segfault when --inout opt

### DIFF
--- a/jsk_topic_tools/cmake/single_nodelet_exec.cpp.in
+++ b/jsk_topic_tools/cmake/single_nodelet_exec.cpp.in
@@ -103,7 +103,7 @@ int main(int argc, char **argv)
       std::cout << "[WARNING] See: https://github.com/jsk-ros-pkg/jsk_common/issues/1145" << std::endl;
     }
     ros::param::set("~always_subscribe", original_value);  // restore always_subscribe value
-    exit(0);
+    return 0;
   }
 
   manager.load(ros::this_node::getName(), "@NODELET@", remappings, my_argv);


### PR DESCRIPTION
Modified:
  - jsk_topic_tools/cmake/single_nodelet_exec.cpp.in