### PR TITLE
queue_size is new in hydro and necessary from indigo

### DIFF
--- a/jsk_coordination_system/dynamic_tf_publisher/src/tf_publish.py
+++ b/jsk_coordination_system/dynamic_tf_publisher/src/tf_publish.py
@@ -18,9 +18,7 @@ import tf.msg
 import thread
 from threading import Lock
 import yaml
-import os
-if os.getenv('ROS_DISTRO') != 'electric' :
-    import genpy
+import genpy
 
 class dynamic_tf_publisher:
     def advertiseServiceUnlessFound(self, name, srv, callback):
@@ -31,8 +29,8 @@ class dynamic_tf_publisher:
         except rospy.ROSException, e:
             rospy.Service(name, srv, callback)
     def __init__(self):
-        self.pub_tf = rospy.Publisher("/tf", tf.msg.tfMessage) if (os.getenv('ROS_DISTRO') in ['electric', 'fuerte', 'groovy']) else rospy.Publisher("/tf", tf.msg.tfMessage, queue_size=1)
-        self.pub_tf_mine = rospy.Publisher("~tf", tf.msg.tfMessage) if (os.getenv('ROS_DISTRO') in ['electric', 'fuerte', 'groovy']) else rospy.Publisher("~tf", tf.msg.tfMessage, queue_size=1)
+        self.pub_tf = rospy.Publisher("/tf", tf.msg.tfMessage, queue_size=1)
+        self.pub_tf_mine = rospy.Publisher("~tf", tf.msg.tfMessage, queue_size=1)
         self.cur_tf = dict()
         self.original_parent = dict()
         self.update_tf = dict()
@@ -47,10 +45,7 @@ class dynamic_tf_publisher:
         # check the cache
         if self.use_cache and rospy.has_param('dynamic_tf_publisher'+rospy.get_name()) :
             tfm = tf.msg.tfMessage()
-            if os.getenv('ROS_DISTRO') != 'electric' :
-                genpy.message.fill_message_args(tfm,[yaml.load(rospy.get_param('dynamic_tf_publisher'+rospy.get_name()))])
-            else :
-                roslib.message.fill_message_args(tfm,[yaml.load(rospy.get_param('dynamic_tf_publisher'+rospy.get_name()))])
+            roslib.message.fill_message_args(tfm,[yaml.load(rospy.get_param('dynamic_tf_publisher'+rospy.get_name()))])
             for pose in tfm.transforms :
                 self.cur_tf[pose.child_frame_id] = pose
         self.advertiseServiceUnlessFound('/set_dynamic_tf', SetDynamicTF, self.set_tf)

--- a/jsk_coordination_system/dynamic_tf_publisher/src/tf_publish.py
+++ b/jsk_coordination_system/dynamic_tf_publisher/src/tf_publish.py
@@ -31,8 +31,8 @@ class dynamic_tf_publisher:
         except rospy.ROSException, e:
             rospy.Service(name, srv, callback)
     def __init__(self):
-        self.pub_tf = rospy.Publisher("/tf", tf.msg.tfMessage)
-        self.pub_tf_mine = rospy.Publisher("~tf", tf.msg.tfMessage)
+        self.pub_tf = rospy.Publisher("/tf", tf.msg.tfMessage) if (os.getenv('ROS_DISTRO') in ['electric', 'fuerte', 'groovy']) else rospy.Publisher("/tf", tf.msg.tfMessage, queue_size=1)
+        self.pub_tf_mine = rospy.Publisher("~tf", tf.msg.tfMessage) if (os.getenv('ROS_DISTRO') in ['electric', 'fuerte', 'groovy']) else rospy.Publisher("~tf", tf.msg.tfMessage, queue_size=1)
         self.cur_tf = dict()
         self.original_parent = dict()
         self.update_tf = dict()

--- a/jsk_coordination_system/dynamic_tf_publisher/src/tf_publish.py
+++ b/jsk_coordination_system/dynamic_tf_publisher/src/tf_publish.py
@@ -18,7 +18,6 @@ import tf.msg
 import thread
 from threading import Lock
 import yaml
-import genpy
 
 class dynamic_tf_publisher:
     def advertiseServiceUnlessFound(self, name, srv, callback):


### PR DESCRIPTION
indigoからはqueue_sizeを指定しないと以下のように警告が出るようです．
queue_sizeはhydroから実装されているようです．

```bash
/home/player/ros/indigo/src/jsk-ros-pkg/jsk_common/jsk_coordination_system/dynamic_tf_publisher/src/tf_publish.py:34: SyntaxWarning: The publisher should be created with an explicit keyword argument 'queue_size'. Please see http://wiki.ros.org/rospy/Overview/Publishers%20and%20Subscribers for more information.
  self.pub_tf = rospy.Publisher("/tf", tf.msg.tfMessage)
```

- http://wiki.ros.org/rospy/Overview/Publishers%20and%20Subscribers