### PR TITLE
Update force_to_rename_changelog_user.py

### DIFF
--- a/jsk_tools/bin/force_to_rename_changelog_user.py
+++ b/jsk_tools/bin/force_to_rename_changelog_user.py
@@ -34,7 +34,7 @@ REPLACE_RULES={
     "iori": "Iori Kumagai",
     "wesleypchan": "Wesley Chan",
     "mmurooka": "Masaki Murooka",
-    "MasakiMurooka": "Masaki Murooka",
+    "masakimurooka": "Masaki Murooka",
     "iory": "Iori Yanokura"}
 
 def remove_duplicates(values):


### PR DESCRIPTION
https://github.com/jsk-ros-pkg/jsk_common/blob/master/jsk_tools/bin/force_to_rename_changelog_user.py#L58 checks key with lower case, if there is a way to find key with case-insensitive like `(find author autohr_list :test #'(lambda (x y) (str= (lower-case x) (lower-case y)))`, please let me know, 
```
            author = author.lower()
            if author in REPLACE_RULES:
                replaced_authors.append(REPLACE_RULES[author])
``