### PR TITLE
[jsk_tools] Copy rviz display to duplicate same config

### DIFF
--- a/jsk_tools/bin/copy_rviz_display.py
+++ b/jsk_tools/bin/copy_rviz_display.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import argparse
+import yaml
+import shutil
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('rviz_file', help='Rviz config filename')
+    args = parser.parse_args()
+
+    rviz_file = args.rviz_file
+
+    rviz_cfg = yaml.load(open(rviz_file))
+    displays = rviz_cfg['Visualization Manager']['Displays']
+
+    print('Which do you wanna copy?:')
+    for i, d in enumerate(displays):
+        print('- {id} name: {Name}, class: {Class}'.format(id=i, **d))
+    selected = int(raw_input('select: '))
+    yn = raw_input('''- {id} name: {Name}, class: {Class}
+You selected above. Are you sure? [yN]:'''\
+        .format(id=selected, **displays[selected]))
+
+    if yn.lower() != 'y':
+        print('Aborted!')
+        return
+
+    shutil.copy(rviz_file, rviz_file + '.bak')
+    copy_element = displays[selected].copy()
+    copy_element['Name'] += ' Copied'
+    rviz_cfg['Visualization Manager']['Displays'].append(copy_element)
+    yaml.dump(rviz_cfg, open(rviz_file, 'wb'))
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except KeyboardInterrupt:
+        print('Aborted!')


### PR DESCRIPTION
Added:
  - jsk_tools/bin/copy_rviz_display.py

## 1
<img src="https://cloud.githubusercontent.com/assets/4310419/13580459/b6ca1242-e4e5-11e5-9e68-f740e41e7ee9.png" width="30%" />

## 2
<img src="https://cloud.githubusercontent.com/assets/4310419/13580478/cdd187d6-e4e5-11e5-9b45-135ced75a2d6.png" width="30%" />


## 3
<img src="https://cloud.githubusercontent.com/assets/4310419/13580481/d21f96de-e4e5-11e5-88a1-3a9e01a73b08.png" width="30%" />
