### PR TITLE
[jsk_tools] Handle shell and dotfiles for shared computers

### DIFF
--- a/doc/jsk_tools/cltools/config_switch.rst
+++ b/doc/jsk_tools/cltools/config_switch.rst
@@ -1,0 +1,39 @@
+config_switch
+=============
+
+Seamlessly switch user configuration with dotfiles and shell.
+
+Currently supports below dotfiles:
+
+  - .bashrc
+  - .zshrc
+  - .vimrc
+  - .vim
+  - .gitconfig
+
+Usage
+-----
+
+.. code-block:: bash
+
+  $ gh_user=wkentaro
+  $ vim ~/.zshrc.$gh_user
+  $ vim ~/.vimrc.$gh_user
+
+  # set user and shell
+  $ config_switch wkentaro /usr/local/bin/zsh
+  Switching user: -> wkentaro
+  Linked .bashrc -> .bashrc.wkentaro
+  WARNING: .zshrc is not symlink, so skipping
+  Logging in as 'wkentaro' with '/usr/local/bin/zsh'
+
+  $ ls -la ~/.vimrc
+  ~/.vimrc -> ~/.vimrc.wkentaro
+
+  $ cat ~/.ros/jsk_tools/current_config
+  wkentaro
+  /usr/local/bin/zsh
+
+  $ config_switch
+  Current user: wkentaro
+  Current shell: /usr/local/bin/zsh

--- a/jsk_tools/CMakeLists.txt
+++ b/jsk_tools/CMakeLists.txt
@@ -11,6 +11,7 @@ catkin_package(
   DEPENDS #
   CFG_EXTRAS download_package.cmake
   )
+catkin_add_env_hooks(99.config_switch SHELLS bash zsh DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/env-hooks)
 catkin_add_env_hooks(99.jsk_tools SHELLS sh bash zsh DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/env-hooks)
 catkin_add_env_hooks(99.jsk_tools-completion SHELLS bash zsh DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/env-hooks)
 

--- a/jsk_tools/env-hooks/99.config_switch.bash
+++ b/jsk_tools/env-hooks/99.config_switch.bash
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+config_switch () {
+  [ -z $ROS_HOME ] && ros_home=$HOME/.ros || ros_home=$ROS_HOME
+  config_dir=$ros_home/jsk_tools
+  link_files=(.bashrc .zshrc .vimrc .vim .gitconfig)
+  [ ! -e $config_dir ] && mkdir -p $config_dir
+  if [ -e $config_dir/current_config ]; then
+    current_user="$(sed -n 1p $config_dir/current_config)"
+    current_shell="$(sed -n 2p $config_dir/current_config)"
+  fi
+  if [ ! $# -eq 2 ]; then
+    echo "Current user: $current_user"
+    echo "Current shell: $current_shell"
+    if [ -e "$current_shell" ]; then
+      exec $current_shell --login
+    fi
+    return 1
+  fi
+  gh_user=$1
+  shell=$2
+  echo "Switching user: $current_user -> $gh_user"
+  echo $gh_user > $config_dir/current_config
+  echo $shell >> $config_dir/current_config
+  for file in $link_files; do
+    if [ -e ~/$file.$gh_user ]; then
+      if [ -L ~/$file -a -d ~/$file ]; then
+        rm ~/$file
+      fi
+      if [ ! -L ~/$file -a -f ~/$file ]; then
+        echo "WARNING: $file is not symlink, so skipping"
+        continue
+      fi
+      ln -sf ~/$file.$gh_user ~/$file
+      echo "Linked $file -> $file.$gh_user"
+    fi
+  done
+  echo "Logging in as '$gh_user' with '$shell'"
+  exec $shell --login
+}

--- a/jsk_tools/env-hooks/99.config_switch.zsh
+++ b/jsk_tools/env-hooks/99.config_switch.zsh
@@ -1,0 +1,12 @@
+#!/usr/bin/env zsh
+
+# source 99.config_switch.bash from same directory as this file
+_THIS_DIR=$(builtin cd -q "`dirname "$0"`" > /dev/null && pwd)
+if [ -f "$_THIS_DIR/99.config_switch.bash" ]; then
+    source "$_THIS_DIR/99.config_switch.bash"
+else
+    # this is temporary code to avoid error caused by bug in ros/catkin
+    # see https://github.com/jsk-ros-pkg/jsk_common/issues/885
+    source "$_THIS_DIR/etc/catkin/profile.d/99.config_switch.bash"
+fi
+unset _THIS_DIR


### PR DESCRIPTION
Modified:
  - jsk_tools/CMakeLists.txt

Added:
  - jsk_tools/env-hooks/99.dotfile.bash
  - jsk_tools/env-hooks/99.dotfile.zsh

### Usage
```
$ config_switch wkentaro /bin/bash
Switching user: wkentaro -> wkentaro
Linked .bashrc -> .bashrc.wkentaro
Linked .zshrc -> .zshrc.wkentaro
Linked .vimrc -> .vimrc.wkentaro
Linked .vim -> .vim.wkentaro
Linked .gitconfig -> .gitconfig.wkentaro
Logging in as 'wkentaro' with '/bin/bash'
$ cat ~/.ros/jsk_tools/current_config
wkentaro
/bin/bash
$ config_switch
Current user: wkentaro
Current shell: /bin/bash
```