### PR TITLE
[jsk_tools] Stable ros version check by STRGREATER

### DIFF
--- a/jsk_tools/CMakeLists.txt
+++ b/jsk_tools/CMakeLists.txt
@@ -39,11 +39,7 @@ if (CATKIN_ENABLE_TESTING)
   roslint_python(src/jsk_tools/cltool.py)
   roslint_add_test()
   find_package(rostest REQUIRED)
-  # check ros distro >= indigo
-  execute_process(
-    COMMAND python -c "import sys; sys.exit(ord('$ENV{ROS_DISTRO}'[0]) >= ord('indigo'[0]))"
-    RESULT_VARIABLE DISTRO_GE_INDIGO)
-  if(${DISTRO_GE_INDIGO})
+  if("$ENV{ROS_DISTRO}" STRGREATER "hydro")
     # FIXME: jsk_tools/test_topic_published.py does not work on hydro travis/jenkins
     # https://github.com/jsk-ros-pkg/jsk_common/pull/1293#issuecomment-164158260
     add_rostest(test/test_topic_published.launch)


### PR DESCRIPTION
Because using python -c 'import sys; sys.exit(ord('$ENV{ROS_DISTRO}') >= ord('indigo'))' is redundant and sometimes fails unexpectedly.