### PR TITLE
[jsk_topic_tools] test_topic_published.py waits when rosbag is used

### DIFF
--- a/jsk_tools/src/test_topic_published.py
+++ b/jsk_tools/src/test_topic_published.py
@@ -39,6 +39,10 @@ class TestTopicPublished(unittest.TestCase):
 
     def test_published(self):
         """Test topics are published and messages come"""
+        use_sim_time = rospy.get_param('/use_sim_time', False)                                
+        while use_sim_time and (rospy.Time.now() == rospy.Time(0)):                           
+            rospy.logwarn('/use_sim_time is specified and rostime is 0, /clock is published?')
+            rospy.sleep(0.1)                                                                  
         checkers = []
         for topic_name, timeout in zip(self.topics, self.timeouts):
             checker = TopicPublishedChecker(topic_name, timeout)


### PR DESCRIPTION
When ``/use_sim_time`` is true, the time is temporary set to 0.000000 at initiation of a program.
This causes `TopicPublishedChecker` to crash. A launch file that crashes with this program is below.
The rosbag in the launch file can be downloaded from here.
https://drive.google.com/file/d/0BzBTxmVQJTrGRERod3E5S3RxdE0/view?usp=sharing

```
<launch>
  <param name="/use_sim_time" value="true" type="bool"/> 
  <node name="rosbag_play"
    pkg="rosbag" type="play"
    args="$(find jsk_2016_01_baxter_apc)/test_data/sib_kinect2.bag --loop --clock">
  </node>

<test test-name="sib_test"
      name="sib_test"
      pkg="jsk_tools" type="test_topic_published.py">
    <rosparam>
      topic_0: /kinect2_torso/hd/camera_info
      timeout_0: 10
    </rosparam>
</test>
</launch>
```

