### PR TITLE
[jsk_common] comment out PR2/arm_navigation_msgs in jsk.rosinstall

### DIFF
--- a/jsk.rosinstall
+++ b/jsk.rosinstall
@@ -200,10 +200,10 @@
     local-name: kinematics_msgs
     uri: 'https://github.com/PR2/kinematics_msgs.git'
     version: hydro-devel
-- git:
-    local-name: arm_navigation_msgs
-    uri: 'https://github.com/PR2/arm_navigation_msgs.git'
-    version: hydro-devel
+# - git:
+#     local-name: arm_navigation_msgs
+#     uri: 'https://github.com/PR2/arm_navigation_msgs.git'
+#     version: hydro-devel
 - git:
     local-name: pr2_kinematics
     uri: 'https://github.com/PR2/pr2_kinematics.git'


### PR DESCRIPTION
Because PR2/arm_navigation_msgs and  jsk_planning/openrave_planning/arm_navigation_msgs are duplicates