### PR TITLE
Implement logXXX_throttle for Python to write log periodically

### DIFF
--- a/jsk_topic_tools/src/jsk_topic_tools/log_utils.py
+++ b/jsk_topic_tools/src/jsk_topic_tools/log_utils.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import cPickle as pickle
 import inspect
 
 import rosgraph
@@ -41,6 +42,56 @@ def jsk_logerr(msg):
 
 def jsk_logfatal(msg):
     rospy.logfatal(_log_msg_with_called_location(msg))
+
+
+class LoggingThrottle(object):
+
+    last_logging_time_table = {}
+
+    def __call__(self, id, logging_func, period, msg):
+        """Do logging specified message periodically.
+
+        - id (str): Id to identify the caller
+        - logging_func (function): Function to do logging.
+        - period (float): Period to do logging in second unit.
+        - msg (object): Message to do logging.
+        """
+        now = rospy.Time.now()
+
+        last_logging_time = self.last_logging_time_table.get(id)
+
+        if (last_logging_time is None or
+              (now - last_logging_time) > rospy.Duration(period)):
+            logging_func(msg)
+            self.last_logging_time_table[id] = now
+
+
+_logging_throttle = LoggingThrottle()
+
+
+def logdebug_throttle(period, msg):
+    id = pickle.dumps(inspect.stack()[1][1:])
+    _logging_throttle(id, rospy.logdebug, period, msg)
+
+
+def loginfo_throttle(period, msg):
+    id = pickle.dumps(inspect.stack()[1][1:])
+    _logging_throttle(id, rospy.loginfo, period, msg)
+
+
+def logwarn_throttle(period, msg):
+    id = pickle.dumps(inspect.stack()[1][1:])
+    _logging_throttle(id, rospy.logwarn, period, msg)
+
+
+def logerr_throttle(period, msg):
+    id = pickle.dumps(inspect.stack()[1][1:])
+    _logging_throttle(id, rospy.logerr, period, msg)
+
+
+def logfatal_throttle(period, msg):
+    id = pickle.dumps(inspect.stack()[1][1:])
+    _logging_throttle(id, rospy.logfatal, period, msg)
 
 
 def warn_no_remap(*names):

--- a/jsk_topic_tools/test/test_python_log_utils.py
+++ b/jsk_topic_tools/test/test_python_log_utils.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import cStringIO as StringIO
+import sys
+import unittest
+
+from jsk_topic_tools.log_utils import LoggingThrottle
+import rospy
+
+
+PKG = 'jsk_topic_tools'
+NAME = 'test_python_log_utils'
+
+
+class TestPythonLogUtils(unittest.TestCase):
+
+    def setUp(self):
+        rospy.init_node(NAME)
+        self.logging_throttle = LoggingThrottle()
+
+    def _check(self, no_logging=False):
+        sys.stdout = f = StringIO.StringIO()
+        self.logging_throttle(id='a', logging_func=print, period=3, msg='spam')
+        sys.stdout = sys.__stdout__
+        if no_logging:
+            self.assertFalse(f.getvalue(), 'spam\n')
+        else:
+            self.assertEqual(f.getvalue(), 'spam\n')
+
+    def test_LoggingThrottle(self):
+        self._check()
+        self._check(no_logging=True)
+        rospy.sleep(rospy.Duration(3))
+        self._check()
+
+
+if __name__ == '__main__':
+    import rostest
+    rostest.rosrun(PKG, NAME, TestPythonLogUtils)

--- a/jsk_topic_tools/test/test_python_log_utils.test
+++ b/jsk_topic_tools/test/test_python_log_utils.test
@@ -1,0 +1,8 @@
+<launch>
+
+  <test test-name="test_python_log_utils"
+        name="test_python_log_utils"
+        pkg="jsk_topic_tools" type="test_python_log_utils.py">
+  </test>
+
+</launch>


### PR DESCRIPTION
### Why?

In roscpp, there is ROS_XXX_THROTTLE to write log periodically.
http://wiki.ros.org/rospy/Overview/Logging

```
ROS_DEBUG_THROTTLE(60, "This message will print every 60 seconds");
```

In rospy, there is **no** logXXX_throttle like logwarn_throttle.
http://wiki.ros.org/rospy/Overview/Logging