### PR TITLE
[jsk_data] add bagfile_prefix arg for record.launch

### DIFF
--- a/jsk_data/CMakeLists.txt
+++ b/jsk_data/CMakeLists.txt
@@ -26,4 +26,12 @@ if (CATKIN_ENABLE_TESTING)
   roslint_add_test()
 
   catkin_add_nosetests(src/jsk_data/tests)
+
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(launch/baxter_play.launch)
+  roslaunch_add_file_check(launch/baxter_record.launch)
+  roslaunch_add_file_check(launch/hrp2_record.launch)
+  roslaunch_add_file_check(launch/pr2_play.launch)
+  roslaunch_add_file_check(launch/pr2_record.launch)
+  roslaunch_add_file_check(launch/urata_record.launch)
 endif()

--- a/jsk_data/launch/baxter_record.launch
+++ b/jsk_data/launch/baxter_record.launch
@@ -11,6 +11,7 @@
   <arg name="save_hand_range" default="true" />
   <arg name="camera_namespace" default="openni"/>
   <arg name="save_dir" default="/tmp/bagfile/"/>
+  <arg name="bagfile_prefix" default="" />
   <!--                          -->
   <!--       Conditions         -->
   <!--                          -->
@@ -40,6 +41,7 @@
     <arg name="save_all_image" value="$(arg save_all_image)" />
     <arg name="camera_namespace" value="$(arg camera_namespace)" />
     <arg name="save_dir" value="$(arg save_dir)" />
+    <arg name="bagfile_prefix" value="$(arg bagfile_prefix)" />
     <arg name="other_options" value="$(arg other_options)" />
     <arg name="other_topics" value="$(arg other_topics)
 				    $(arg robot_model_topics)

--- a/jsk_data/launch/common_record.launch
+++ b/jsk_data/launch/common_record.launch
@@ -11,7 +11,8 @@
   <arg name="save_multisense" default="false" />
   <arg name="camera_namespace" default="openni"/>
   
-  <arg name="save_dir" default="$(env HOME)/.ros"/>
+  <arg name="save_dir" default="$(env HOME)/.ros" /> <!-- destination directory of bagfile -->
+  <arg name="bagfile_prefix"/> <!-- prefix of bagfile name (filename is prefix_date.bag) -->
   <param name="mk_save_dir" command="mkdir -p $(arg save_dir)" />
   <!--                          -->
   <!--       Conditions         -->
@@ -50,7 +51,7 @@
               $(arg openni2_topics) 
               $(arg robot_model_topics) 
               $(arg other_topics)
-              -o $(arg save_dir) 
+              -o $(arg save_dir)/$(arg bagfile_prefix)
               $(arg other_options)
 	      -e
               $(arg all_image_topics)

--- a/jsk_data/launch/hrp2_record.launch
+++ b/jsk_data/launch/hrp2_record.launch
@@ -1,6 +1,7 @@
 <launch>
   <!-- for HRP2 -->
   <arg name="save_dir" default="/tmp/hrp2_rosbag"/>
+  <arg name="bagfile_prefix" default="" />
   <arg name="camera_namespace" default="camera" />
   <arg name="save_openni" default="true" />
   <arg name="save_robot_model" default="true" />
@@ -27,6 +28,7 @@
                                     /off_lhsensor
                                     /off_rhsensor
                                     /zmp" />
-    <arg name="save_dir" value="$(arg save_dir)" />    
+    <arg name="save_dir" value="$(arg save_dir)" />
+    <arg name="bagfile_prefix" value="$(arg bagfile_prefix)" />
   </include>
 </launch>

--- a/jsk_data/launch/pr2_record.launch
+++ b/jsk_data/launch/pr2_record.launch
@@ -13,6 +13,7 @@
   <arg name="save_prosilica" default="false" />
   <arg name="camera_namespace" default="openni"/>
   <arg name="save_dir" default="/removable/bagfile/"/>
+  <arg name="bagfile_prefix" default="data" />
   <arg name="remove_c2" default="true" />
   <!--                          -->
   <!--       Conditions         -->
@@ -63,6 +64,7 @@
     <arg name="save_all_image" value="$(arg save_all_image)" />
     <arg name="camera_namespace" value="$(arg camera_namespace)" />
     <arg name="save_dir" value="$(arg save_dir)" />
+    <arg name="bagfile_prefix" value="$(arg bagfile_prefix)" />
     <arg name="other_options" value="$(arg other_options)" />
     <arg name="other_topics" value="$(arg other_topics)
                                     $(arg base_scan_topics)

--- a/jsk_data/launch/template_pr2_record.launch
+++ b/jsk_data/launch/template_pr2_record.launch
@@ -14,6 +14,7 @@
     <arg name="save_gripper_command" default="true" />
     <arg name="camera_namespace" value="openni"/>
     <arg name="save_dir" value="/removable/bagfile/"/>
+    <arg name="bagfile_prefix" value="data" />
   </include>
 
 </launch>

--- a/jsk_data/launch/urata_record.launch
+++ b/jsk_data/launch/urata_record.launch
@@ -4,6 +4,7 @@
   <arg name="other_topics" default=""/>
   <arg name="other_options" default="--split --duration 2m"/>
   <arg name="save_dir" default="$(env HOME)/.ros/urata_record"/>
+  <arg name="bagfile_prefix" default="" />
   <!-- URATA robot default topics -->
   <arg name="urata_topics" default="/imu
                                     /act_contact_states /ref_contact_states
@@ -26,6 +27,7 @@
     <arg name="save_all_image" value="false" />
     <arg name="save_multisense" value="false" />
     <arg name="save_dir" value="$(arg save_dir)" />
+    <arg name="bagfile_prefix" value="$(arg bagfile_prefix)" />
     <arg name="other_options" value="$(arg other_options)" />
     <arg name="other_topics" value="$(arg other_topics)
                                     $(arg urata_topics)

--- a/jsk_data/package.xml
+++ b/jsk_data/package.xml
@@ -10,14 +10,21 @@
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>message_generation</build_depend>
   <run_depend>depth_image_proc</run_depend>
+  <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>image_transport</run_depend>
   <run_depend>jsk_topic_tools</run_depend>
   <run_depend>message_runtime</run_depend>
+  <run_depend>nodelet</run_depend>
+  <run_depend>openni_launch</run_depend>
   <run_depend>paramiko</run_depend>
   <run_depend>python-click</run_depend>
   <run_depend>python-yaml</run_depend>  <!-- apt -->
+  <run_depend>rosbag</run_depend>
+  <run_depend>rqt_bag</run_depend>
+  <run_depend>rviz</run_depend>
   <test_depend>python-freezegun-pip</test_depend>
   <test_depend>python-nose</test_depend>
+  <test_depend>roslaunch</test_depend>
   <test_depend>roslint</test_depend>
   <export>
   </export>

--- a/jsk_data/package.xml
+++ b/jsk_data/package.xml
@@ -9,6 +9,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>message_generation</build_depend>
+  <run_depend>baxter_description</run_depend>
   <run_depend>depth_image_proc</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>image_transport</run_depend>

--- a/jsk_data/package.xml
+++ b/jsk_data/package.xml
@@ -23,6 +23,7 @@
   <run_depend>rosbag</run_depend>
   <run_depend>rqt_bag</run_depend>
   <run_depend>rviz</run_depend>
+  <run_depend>xacro</run_depend>
   <test_depend>python-freezegun-pip</test_depend>
   <test_depend>python-nose</test_depend>
   <test_depend>roslaunch</test_depend>

--- a/jsk_data/package.xml
+++ b/jsk_data/package.xml
@@ -18,6 +18,7 @@
   <run_depend>nodelet</run_depend>
   <run_depend>openni_launch</run_depend>
   <run_depend>paramiko</run_depend>
+  <run_depend>pr2_description</run_depend>
   <run_depend>python-click</run_depend>
   <run_depend>python-yaml</run_depend>  <!-- apt -->
   <run_depend>rosbag</run_depend>


### PR DESCRIPTION
- add `bagfile_prefix` argument for `XXX_record.launch`

destination bag file is `$(arg save_dir)/$(arg bagfile_prefix)_YYYY-mm-dd-HH-MM-SS.bag`

Without this PR, we can set only directory and prefix is always empty.

```bash
/removable/bagfile/furushchev/elevator_20160106$ ls
_2016-01-05-23-50-54.bag  _2016-01-14-13-22-40.bag  _2016-01-18-06-35-41.bag  _2016-01-20-11-00-44.bag
_2016-01-05-23-59-42.bag  _2016-01-14-13-30-23.bag  _2016-01-18-06-37-03.bag  _2016-01-20-13-28-10.bag.active
_2016-01-06-00-24-13.bag  _2016-01-14-13-38-59.bag  _2016-01-20-08-28-31.bag  _2016-01-20-13-28-10.bag.orig.active
_2016-01-14-12-50-16.bag  _2016-01-14-13-47-10.bag  _2016-01-20-08-35-36.bag  _2016-01-20-22-28-59.bag.active
_2016-01-14-12-51-39.bag  _2016-01-14-13-50-01.bag  _2016-01-20-09-58-33.bag  _2016-01-20-22-28-59.bag.orig.active
_2016-01-14-12-53-00.bag  _2016-01-14-13-58-04.bag  _2016-01-20-10-00-51.bag
_2016-01-14-12-53-38.bag  _2016-01-18-04-09-10.bag  _2016-01-20-10-03-20.bag
_2016-01-14-13-00-23.bag  _2016-01-18-04-30-19.bag  _2016-01-20-10-22-35.bag
```

- add test for roslanch