### PR TITLE
[jsk_topic_tools] Fix missing installation of jsk_topic_tools_test_nodelet.xml

### DIFF
--- a/jsk_topic_tools/CMakeLists.txt
+++ b/jsk_topic_tools/CMakeLists.txt
@@ -150,7 +150,9 @@ install(TARGETS topic_buffer_server topic_buffer_client jsk_topic_tools
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
   )
 
-install(FILES jsk_topic_tools_nodelet.xml
+install(FILES
+  jsk_topic_tools_nodelet.xml
+  jsk_topic_tools_test_nodelet.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 install(DIRECTORY include/${PROJECT_NAME}/


### PR DESCRIPTION
This is critical because the xml file is declared in package.xml.
If I install jsk_topic_tools with apt, launch file with nodelet
won't work because of not found error.
Could you please merge this and release next version, soon?