### PR TITLE
catch if package is not found / do not download the data if the target directory is not writeable

### DIFF
--- a/jsk_data/src/jsk_data/download_data.py
+++ b/jsk_data/src/jsk_data/download_data.py
@@ -81,6 +81,11 @@ def download_data(pkg_name, path, url, md5, download_client=None,
     if not osp.isabs(path):
         # get package path
         rp = rospkg.RosPack()
+        try:
+            pkg_path = rp.get_path(pkg_name)
+        except rospkg.ResourceNotFound:
+            print('\033[31m{name} is not found in {path}\033[0m'.format(name=pkg_name, path=rp.list()))
+            return
         pkg_path = rp.get_path(pkg_name)
         path = osp.join(pkg_path, path)
     # prepare cache dir

--- a/jsk_data/src/jsk_data/download_data.py
+++ b/jsk_data/src/jsk_data/download_data.py
@@ -88,6 +88,12 @@ def download_data(pkg_name, path, url, md5, download_client=None,
             return
         pkg_path = rp.get_path(pkg_name)
         path = osp.join(pkg_path, path)
+        if not osp.exists(osp.dirname(path)):
+            try:
+                os.makedirs(osp.dirname(path))
+            except OSError as e:
+                print('\033[31mCould not make direcotry {dir} {err}\033[0m'.format(dir=osp.dirname(path), err=e))
+                return
     # prepare cache dir
     ros_home = os.getenv('ROS_HOME', osp.expanduser('~/.ros'))
     cache_dir = osp.join(ros_home, 'data', pkg_name)
@@ -104,8 +110,6 @@ def download_data(pkg_name, path, url, md5, download_client=None,
         os.remove(path)
         os.symlink(cache_file, path)
     elif not osp.exists(path):
-        if not osp.exists(osp.dirname(path)):
-            os.makedirs(osp.dirname(path))
         os.symlink(cache_file, path)  # create link
     else:
         # not link and exists so skipping


### PR DESCRIPTION
Somehow the empty directory is not copied to the release repository, and I think it's ok to not to include sample/trained data into deb package as for now...

https://github.com/jsk-ros-pkg/jsk_recognition/tree/master/jsk_perception/sample/data
https://github.com/tork-a/jsk_recognition-release/tree/debian/indigo/trusty/jsk_perception/data

Current error message is something like this, and if we do not install jsk_perception,

```
make[4]: Leaving directory `/tmp/jsk_recognition-release/obj-x86_64-linux-gnu'
make -f CMakeFiles/install_sample_data.dir/build.make CMakeFiles/install_sample_data.dir/build
make[4]: Entering directory `/tmp/jsk_recognition-release/obj-x86_64-linux-gnu'
../scripts/install_sample_data.py
Checking md5sum of '/home/k-okada/.ros/data/2016-06-10-23-01-28_in_lab.bag'...
...done
Traceback (most recent call last):
  File "../scripts/install_sample_data.py", line 22, in <module>
    main()
  File "../scripts/install_sample_data.py", line 16, in main
    'sample/data/2016-06-10-23-01-28_in_lab.bag',
  File "/opt/ros/indigo/lib/python2.7/dist-packages/jsk_data/download_data.py", line 103, in download_data
    os.makedirs(osp.dirname(path))
  File "/usr/lib/python2.7/os.py", line 157, in makedirs
    mkdir(name, mode)
OSError: [Errno 13] Permission denied: '/opt/ros/indigo/share/jsk_perception/sample/data'
make[4]: *** [CMakeFiles/install_sample_data] Error 1
```

we'll get 
```
../scripts/install_sample_data.py
Traceback (most recent call last):
  File "../scripts/install_sample_data.py", line 22, in <module>
    main()
  File "../scripts/install_sample_data.py", line 16, in main
    'sample/data/2016-06-10-23-01-28_in_lab.bag',
  File "/opt/ros/indigo/lib/python2.7/dist-packages/jsk_data/download_data.py", line 84, in download_data
    pkg_path = rp.get_path(pkg_name)
  File "/usr/lib/python2.7/dist-packages/rospkg/rospack.py", line 200, in get_path
    raise ResourceNotFound(name, ros_paths=self._ros_paths)
rospkg.common.ResourceNotFound: jsk_perception
ROS path [0]=/opt/ros/indigo/share/ros
ROS path [1]=/opt/ros/indigo/share
ROS path [2]=/opt/ros/indigo/stacks
```