### PR TITLE
[jsk_data/src/jsk_data/gdrive.py] check token.json

### DIFF
--- a/jsk_data/src/jsk_data/cli.py
+++ b/jsk_data/src/jsk_data/cli.py
@@ -109,7 +109,7 @@ def cmd_ls(public, query, show_size, sort, reverse):
         if ls_options:
             sys.stderr.write(
                 'WARNING: if public=True, ignores all ls options\n')
-        sys.stdout.write(list_gdrive())
+        sys.stdout.write(list_gdrive() or "")
     else:
         print('\n'.join(_list_aries_files(query, ls_options)))
 

--- a/jsk_data/src/jsk_data/gdrive.py
+++ b/jsk_data/src/jsk_data/gdrive.py
@@ -26,7 +26,7 @@ def run_gdrive(args=None, stdout=True):
     config = os.path.join(pkg_ros_home, '.gdrive')
     cmd = 'rosrun jsk_data drive-linux-x64 --config {config} {args}'\
           .format(args=args, config=config)
-    if stdout:
+    if stdout and os.path.exists('{config}/token.json'.format(config=config)):
         return subprocess.check_output(cmd, shell=True)
     else:
         subprocess.call(cmd, shell=True)


### PR DESCRIPTION
jsk_dataの初回のoath2認証についてです。
oath2認証を完了していない際に、
```
jsk_data ls -p
```
などをすると、oath2認証の以下のメッセージ
```
Go to the following link in your browser:
https://accounts.google.com/o/oauth2/...
```
を`jsk_data/scripts/drive-linux-x64`が出力して入力待ちになりますが、
`subprocess.check_output`は
1. コマンドが終了するまで、メッセージを表示しない
2. ctrl-Cされると、そのままエラーになってメッセージを表示しない

ので、oath2認証を行えません。

そこで、oath2認証が終わっていない(`${HOME}/.ros/jsk_data/.gdrive/token.json`が存在しない)時は、`subprocess.call`を利用するようにしました。
