### PR TITLE
[jsk_tools][99.jsk_tools.sh] fix: issue #1472

### DIFF
--- a/jsk_tools/env-hooks/99.jsk_tools.sh
+++ b/jsk_tools/env-hooks/99.jsk_tools.sh
@@ -96,7 +96,7 @@ rossetip_addr() {
         fi
         target_host=$target_host_ip
     fi
-    export ROS_IP=$(ip -o -4 route get $target_host | awk "/$target_host/ "'{print $5}')
+    export ROS_IP=$(ip -o -4 route get $target_host | sed -e 's/^.*src \([0-9.]\+\).*$/\1/g')
     export ROS_HOSTNAME=$ROS_IP
 }
 


### PR DESCRIPTION
we can get self ip address which is used to access to specified ip (host ip) by:

```bash
$ ip -o -4 route get <host ip>
<host ip> via <gateway> dev wlan0  src <ip address>
```

however, if host ip is equal to self, prefix `local` is appended.

```bash
$ ip -o -4 route get <my ip>
local <my ip> via <gateway> dev wlan0  src <my ip>
```

I fixed to use `sed` to parse `src` ip address.