### PR TITLE
[jsk_data] add openni_record.launch openni_play.launch

### DIFF
--- a/jsk_data/launch/openni_play.launch
+++ b/jsk_data/launch/openni_play.launch
@@ -1,0 +1,65 @@
+<launch>
+  <arg name="name" doc="full path to bag file" />
+
+  <arg name="camera_namespace" default="camera" />
+  <arg name="rosbag_option"    default="--clock" />
+  <arg name="compressed"       default="false" />
+  <arg name="use_xterm"        default="false" />
+  <arg name="use_gui"          default="false" />
+
+  <param name="use_sim_time" value="true" />
+
+  <arg name="remapping_namespace" default="$(arg camera_namespace)" unless="$(arg compressed)"/>
+  <arg name="remapping_namespace" default="camera_rosbag" if="$(arg compressed)" />
+
+  <!-- openni -->
+  <include file="$(find openni2_launch)/launch/openni2.launch">
+    <arg name="camera" value="$(arg camera_namespace)"/>
+    <arg name="load_driver" value="false" />
+    <arg name="depth_registration" value="true" />
+  </include>
+
+  <!-- decompress -->
+  <group if="$(arg compressed)">
+    <node name="decompress_rgb"
+          pkg="image_transport" type="republish" args="compressed raw">
+      <remap from="in" to="/$(arg remapping_namespace)/rgb/image_raw" />
+      <remap from="out" to="/$(arg camera_namespace)/rgb/image_raw" />
+    </node>
+    <node name="decompress_depth"
+          pkg="image_transport" type="republish" args="compressedDepth raw">
+      <remap from="in" to="/$(arg remapping_namespace)/depth_registered/image_raw" />
+      <remap from="out" to="/$(arg camera_namespace)/depth_registered/image_raw" />
+    </node>
+  </group>
+
+  <!-- rosbag play -->
+  <group>
+    <!-- remapping for compressed images -->
+    <remap from="/$(arg camera_namespace)/rgb/image_raw/compressed"
+           to="/$(arg remapping_namespace)/rgb/image_raw/compressed"
+           if="$(arg compressed)"/>
+    <remap from="/$(arg camera_namespace)/depth_registered/image_raw/compressedDepth"
+           to="/$(arg remapping_namespace)/depth_registered/image_raw/compressedDepth"
+           if="$(arg compressed)"/>
+
+    <group if="$(arg use_xterm)">
+      <node unless="$(arg use_gui)" pkg="rosbag" type="play" name="rosbag_play"
+            launch-prefix="xterm -e"
+            args="$(arg rosbag_option) $(arg name)">
+        <remap from="/$(arg camera_namespace)" to="/$(arg remapping_namespace)" />
+      </node>
+    </group>
+    <group unless="$(arg use_xterm)">
+      <node unless="$(arg use_gui)" pkg="rosbag" type="play" name="rosbag_play"
+            args="$(arg rosbag_option) $(arg name)" >
+        <remap from="/$(arg camera_namespace)" to="/$(arg remapping_namespace)" />
+      </node>
+    </group>
+    <node if="$(arg use_gui)" pkg="rqt_bag" type="rqt_bag" name="rqt_bag"
+          args="$(arg rosbag_option) $(arg name)">
+      <remap from="/$(arg camera_namespace)" to="/$(arg remapping_namespace)" />
+    </node>
+  </group>
+
+</launch>

--- a/jsk_data/launch/openni_record.launch
+++ b/jsk_data/launch/openni_record.launch
@@ -1,0 +1,45 @@
+<launch>
+  <arg name="name" doc="bag file name prefix" /> <!-- required -->
+
+  <arg name="camera_namespace"        default="camera" />
+  <arg name="record_compressed_rgb"   default="false" />
+  <arg name="record_compressed_depth" default="false" />
+  <arg name="other_topics"            default="/tf" />
+  <arg name="rosbag_option"           default=""
+       doc="options passed as 'rosbag record -o'" />
+
+  <arg name="save_dir"                default="$(optenv HOME /tmp)/" />
+  <!-- workaround to make save directory if not exists -->
+  <param name="mk_save_dir" command="mkdir -p $(arg save_dir)" />
+
+  <!-- rgb image -->
+  <arg unless="$(arg record_compressed_rgb)"
+       name="rgb_topics" value="
+$(arg camera_namespace)/rgb/image_raw
+$(arg camera_namespace)/rgb/camera_info
+"/>
+  <arg if="$(arg record_compressed_rgb)"
+       name="rgb_topics" value="
+$(arg camera_namespace)/rgb/image_raw/compressed
+$(arg camera_namespace)/rgb/camera_info
+"/>
+
+  <!-- depth image -->
+  <arg unless="$(arg record_compressed_depth)"
+       name="depth_topics" value="
+$(arg camera_namespace)/depth_registered/image_raw
+$(arg camera_namespace)/depth_registered/camera_info
+"/>
+  <arg if    ="$(arg record_compressed_depth)"
+       name="depth_topics" value="
+$(arg camera_namespace)/depth_registered/image_raw/compressedDepth
+$(arg camera_namespace)/depth_registered/camera_info
+"/>
+
+  <node name="$(anon rosbag_record)" pkg="rosbag" type="record"
+        args="$(arg rgb_topics)
+              $(arg depth_topics)
+              $(arg other_topics)
+              -o $(arg save_dir)/$(arg name)
+                 $(arg rosbag_option)" />
+</launch>

--- a/jsk_data/package.xml
+++ b/jsk_data/package.xml
@@ -28,6 +28,9 @@
   <run_depend>rqt_bag</run_depend>
   <run_depend>rviz</run_depend>
   <run_depend>xacro</run_depend>
+  <run_depend>image_transport</run_depend>
+  <run_depend>compressed_image_transport</run_depend>
+  <run_depend>compressed_depth_image_transport</run_depend>
   <test_depend>python-freezegun-pip</test_depend>
   <test_depend>python-nose</test_depend>
   <test_depend>roslaunch</test_depend>


### PR DESCRIPTION
Record only depth image instead of pointcloud, but publish pointcloud on play.
support raw / compressed image.

tested with astra s

example usage:

```bash
# record
roslaunch openni2_launch openni2.launch depth_registration:=true
roslaunch jsk_data openni_record.launch name:=icp_2d record_compressed_rgb:=true record_compressed_depth:=true rosbag_option:='--duration=120'

# play
roslaunch jsk_data openni_play.launch name:=`pwd`/icp_2d_2017-03-25-20-52-46.bag rosbag_option:='--clock --loop'
```