### PR TITLE
Remove import error message in ros_console.py

### DIFF
--- a/jsk_tools/bin/ros_console.py
+++ b/jsk_tools/bin/ros_console.py
@@ -2,11 +2,7 @@
 import rospy
 
 import sys
-try:
-    import colorama
-except:
-    print "Please install colorama by pip install colorama"
-    sys.exit(1)
+import colorama
 from colorama import Fore, Style
 import argparse
 from rosgraph_msgs.msg import Log


### PR DESCRIPTION
Because python-colorama is installed via apt

Close #1516

@k-okada maybe you can uncomment the run_depend of python-colorama when releasing