### PR TITLE
CMakeLists.txt : fix install process, bin is already installed to /opt/ros/indigo/lib/jsk_tools/ directory

### DIFF
--- a/jsk_tools/CMakeLists.txt
+++ b/jsk_tools/CMakeLists.txt
@@ -58,7 +58,7 @@ install(DIRECTORY test
   USE_SOURCE_PERMISSIONS
   PATTERN "*.test" EXCLUDE
   )
-install(DIRECTORY src bin dot-files cmake
+install(DIRECTORY src dot-files cmake
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
   USE_SOURCE_PERMISSIONS
   )


### PR DESCRIPTION
currently we're asked to choose executable to run, can we remove `/share/jsk_tools/bin/ros_console.py` and others? if they are called like
```
`rospack find jsk_tools`/bin/ros_console
```

we'll have trouble.

```
$ rosrun jsk_tools ros_console.py  -n talker
[rosrun] You have chosen a non-unique executable, please pick one of the following:
1) /opt/ros/indigo/lib/jsk_tools/ros_console.py
2) /opt/ros/indigo/share/jsk_tools/bin/ros_console.py
```