### PR TITLE
add ROSIntrupptException, not to show strage message on shutting down

### DIFF
--- a/jsk_coordination_system/dynamic_tf_publisher/src/tf_publish.py
+++ b/jsk_coordination_system/dynamic_tf_publisher/src/tf_publish.py
@@ -149,8 +149,11 @@ class dynamic_tf_publisher:
 
 
 if __name__ == "__main__":
-    rospy.init_node('tf_publish_server')
-    pub = dynamic_tf_publisher()
-    while not rospy.is_shutdown():
-        pub.publish_and_sleep()
+    try:
+        rospy.init_node('tf_publish_server')
+        pub = dynamic_tf_publisher()
+        while not rospy.is_shutdown():
+            pub.publish_and_sleep()
+    except rospy.ROSInterruptException:
+        pass
 


### PR DESCRIPTION
to supress message like

```
Traceback (most recent call last):
  File "/opt/ros/indigo/lib/dynamic_tf_publisher/tf_publish.py", line 155, in <module>
    pub.publish_and_sleep()
  File "/opt/ros/indigo/lib/dynamic_tf_publisher/tf_publish.py", line 148, in publish_and_sleep
    rospy.sleep(self.tf_sleep_time)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/rospy/timer.py", line 157, in sleep
    raise rospy.exceptions.ROSInterruptException("ROS shutdown request")

```