### PR TITLE
[jsk_topic_tools] Show deprecation warning for jsk_logxxx logging functions

### DIFF
--- a/jsk_data/node_scripts/data_collection_server.py
+++ b/jsk_data/node_scripts/data_collection_server.py
@@ -16,7 +16,6 @@ import yaml
 import cv_bridge
 import dynamic_reconfigure.server
 import genpy
-from jsk_topic_tools.log_utils import jsk_logfatal
 import message_filters
 import roslib.message
 import rospy
@@ -70,8 +69,8 @@ class DataCollectionServer(object):
             required_fields = ['name', 'msg_class', 'fname', 'savetype']
             for field in required_fields:
                 if field not in topic:
-                    jsk_logfatal("Required field '{}' for topic is missing"
-                                 .format(field))
+                    rospy.logfatal("Required field '{}' for topic is missing"
+                                   .format(field))
                     sys.exit(1)
         self.params = rospy.get_param('~params', [])
         self.slop = rospy.get_param('~slop', 0.1)
@@ -80,8 +79,8 @@ class DataCollectionServer(object):
             required_fields = ['key', 'fname', 'savetype']
             for field in required_fields:
                 if field not in param:
-                    jsk_logfatal("Required field '{}' for param is missing"
-                                 .format(field))
+                    rospy.logfatal("Required field '{}' for param is missing"
+                                   .format(field))
                     sys.exit(1)
         if rospy.get_param('~with_request', True):
             self.subs = []

--- a/jsk_tools/src/delay_timestamp.py
+++ b/jsk_tools/src/delay_timestamp.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from jsk_topic_tools import jsk_logwarn
 from roslib.message import get_message_class
 import rosgraph
 import rospy
@@ -12,8 +11,8 @@ class DelayTimestamp(object):
 
     def __init__(self):
         rospy.init_node('delay_timestamp')
-        jsk_logwarn('This node is mainly designed for TEST. '
-                    'Take care if you use this in your actual system.')
+        rospy.logwarn('This node is mainly designed for TEST. '
+                      'Take care if you use this in your actual system.')
         self._master = rosgraph.Master(rospy.get_name())
         self._delay = rospy.get_param('~delay')
         self._sub = rospy.Subscriber('~input', AnyMsg, self._cb)

--- a/jsk_topic_tools/src/jsk_topic_tools/log_utils.py
+++ b/jsk_topic_tools/src/jsk_topic_tools/log_utils.py
@@ -24,23 +24,35 @@ def _log_msg_with_called_location(msg):
             msg=msg)
 
 
+def _deprecation_warning_jsk_logxxx():
+    rospy.logwarn(
+        'DEPRECATION WARNING: jsk_logxxx log functions are deprecated, and '
+        'please use rospy.logxxx instead. '
+        '(See https://github.com/jsk-ros-pkg/jsk_common/issues/1461)')
+
+
 def jsk_logdebug(msg):
+    _deprecation_warning_jsk_logxxx()
     rospy.logdebug(_log_msg_with_called_location(msg))
 
 
 def jsk_loginfo(msg):
+    _deprecation_warning_jsk_logxxx()
     rospy.loginfo(_log_msg_with_called_location(msg))
 
 
 def jsk_logwarn(msg):
+    _deprecation_warning_jsk_logxxx()
     rospy.logwarn(_log_msg_with_called_location(msg))
 
 
 def jsk_logerr(msg):
+    _deprecation_warning_jsk_logxxx()
     rospy.logerr(_log_msg_with_called_location(msg))
 
 
 def jsk_logfatal(msg):
+    _deprecation_warning_jsk_logxxx()
     rospy.logfatal(_log_msg_with_called_location(msg))
 
 


### PR DESCRIPTION
By https://github.com/jsk-ros-pkg/jsk_common/issues/1461, we found `jsk_logxxx` was not necessary, and we can just run `rospy.logxxx`.