### PR TITLE
need to find pcl_ros for image_view2

### DIFF
--- a/jsk_ros_patch/image_view2/CMakeLists.txt
+++ b/jsk_ros_patch/image_view2/CMakeLists.txt
@@ -9,7 +9,7 @@ if(CCACHE_FOUND)
   set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
 endif(CCACHE_FOUND)
 
-find_package(catkin REQUIRED COMPONENTS roscpp dynamic_reconfigure  cv_bridge std_msgs sensor_msgs geometry_msgs image_transport tf image_geometry message_filters message_generation std_srvs)
+find_package(catkin REQUIRED COMPONENTS roscpp dynamic_reconfigure  cv_bridge std_msgs sensor_msgs geometry_msgs image_transport tf image_geometry message_filters message_generation std_srvs pcl_ros)
 
 generate_dynamic_reconfigure_options(
   cfg/ImageView2.cfg


### PR DESCRIPTION
pcl関連（pcl / pcl_ros / perception_pcl / pcl_convertions）をソースから入れた環境でビルドしてみたら，
```
image_view2.h:63:31: fatal error: pcl_ros/publisher.h: No such file or directory
```
と怒られてしまいましたので，報告しておきます．
https://github.com/jsk-ros-pkg/jsk_common/blob/master/jsk_ros_patch/image_view2/image_view2.h#L63

※ pcl関連をaptから入れたら発生しないです


--- 
以下試行錯誤メモ: thanks to @aginika 
- 2と3は要らない気がする．4が大事そう．
- ``/etc/ld.so.conf``を見ると``/usr/local/lib``（srcで入れると入る方）が``/usr/lib``（aptで入れると入る方）より優先的に見られるようになっているので，変なことしなければaptとsrcが混ざっていても問題ない
- ただ，実際に使われるのはキャッシュ``/etc/ld.so.cache``なので，pclをsrcで入れなおしただけでは上手く行かなかったっぽい．``ldconfig``をしてキャッシュを上書きすればcatkin cleanいらなかったかも．

---

1. pcl1.8をソースから入れる
```bash
git clone https://github.com/PointCloudLibrary/pcl.git
cd pcl
mkdir build; cd build
ccmake .. # build_gpuをonにする
make
sudo make install
```
- http://pointclouds.org/documentation/tutorials/gpu_install.php

2. aptで入ってたpcl1.7を消す

```bash
sudo dpkg --purge --force-all libpcl1.7 libpcl-filters1.7 libpcl-outofcore1.7 libpcl-search1.7 libpcl-apps1.7 libpcl-io1.7 libpcl-people1.7 libpcl-segmentation1.7 libpcl-common1.7 libpcl-kdtree1.7 libpcl-recognition1.7 libpcl-surface1.7 libpcl-dev libpcl-keypoints1.7 libpcl-registration1.7 libpcl-tracking1.7 libpcl-features1.7 libpcl-octree1.7 libpcl-sample-consensus1.7 libpcl-visualization1.7 
```

3. catkin cleanして諸々buildし直そうとすることで，aptで入っていたpcl1.7に依存しているパッケージを見つけ出して，消す
```bash
sudo dpkg --purge --force-all ros-kinetic-pcl-ros ros-kinetic-perception-pcl ros-kinetic-pcl-conversions  ros-kinetic-octomap-server
```

4. 消したパッケージをソースで入れる
```bash
git clone https://github.com/ros-perception/pcl_conversions.git -b indigo-devel
git clone https://github.com/ros-perception/perception_pcl.git -b kinetic-devel
git clone https://github.com/OctoMap/octomap_mapping.git -b kinetic-devel
```

5. catkin cleanして諸々buildしなおしてpcl1.8が使われているかを確認する
- https://github.com/jsk-ros-pkg/jsk_recognition/issues/1838
- https://github.com/jsk-ros-pkg/jsk_recognition/pull/1902


6. 消したパッケージをaptで入れて，aptのbroken状態を治す
```bash
sudo apt-get upgrade
sudo apt-get check
```

7. catkin cleanしてもろもろビルドし直して，6が悪影響していないことを確認する