### PR TITLE
jsk_topic_tools: add stealth_relay for silently subscribing topic

### DIFF
--- a/doc/jsk_topic_tools/lib/stealth_relay_nodelet.md
+++ b/doc/jsk_topic_tools/lib/stealth_relay_nodelet.md
@@ -1,0 +1,36 @@
+# StealthRelay
+
+`jsk_topic_tools/StealthRelay` is a node/nodelet that subscribes to `~input` topic and republishes all incoming data to `~output` topic like `topic_tools/Relay` but only if `~monitor` topic is subscribed by any other nodes.
+
+When `~input` and `~monitoring_topic` topic name point to the same topic, it looks that this node subscribes `~input` topic only when other nodes also subscribes it, which is equivalent to subscribing without incrementing subscription counter.
+`~monitoring_topic` can be set by rosparam and is set to `~input` by default.
+
+## Subscribing Topics
+
+* `~input` (`AnyMsg`)
+
+  Incoming topic to be relayed
+
+## Publishing Topics
+
+* `~output` (`AnyMsg`, same type as `~input`)
+
+  Outgoing topic to publish on
+
+## Parameters
+
+* `~use_multithread_callback` (`bool`, default: `true`)
+
+    If `true`, initialize `NodeHandle` with multi threading.
+
+* `~queue_size` (`int`, default: `1`)
+
+    Queue size for subscription of the incoming topic
+
+* `monitoring_topic` (`string`, default: `~input`)
+
+    Topic name to monitor
+
+* `monitor_rate` (`double`, default: `1.0`)
+
+    Rate to monitor subscription number

--- a/jsk_topic_tools/CMakeLists.txt
+++ b/jsk_topic_tools/CMakeLists.txt
@@ -78,6 +78,8 @@ jsk_topic_tools_nodelet(src/relay_nodelet.cpp
   "jsk_topic_tools/Relay" "relay")
 jsk_topic_tools_nodelet(src/deprecated_relay_nodelet.cpp
   "jsk_topic_tools/DeprecatedRelay" "deprecated_relay")
+jsk_topic_tools_nodelet(src/stealth_relay_nodelet.cpp
+  "jsk_topic_tools/StealthRelay" "stealth_relay")
 jsk_topic_tools_nodelet(src/passthrough_nodelet.cpp
   "jsk_topic_tools/Passthrough" "passthrough")
 jsk_topic_tools_nodelet(src/block_nodelet.cpp
@@ -128,6 +130,7 @@ if (CATKIN_ENABLE_TESTING)
   jsk_topic_tools_add_rostest(test/test_block.test)
   jsk_topic_tools_add_rostest(test/test_connection_based_nodelet.test)
   jsk_topic_tools_add_rostest(test/test_connection_based_transport.test)
+  jsk_topic_tools_add_rostest(test/test_stealth_relay.test)
   catkin_add_nosetests(src/jsk_topic_tools/tests)
   catkin_add_gtest(test_rosparam_utils src/tests/test_rosparam_utils.cpp)
   target_link_libraries(test_rosparam_utils ${PROJECT_NAME})

--- a/jsk_topic_tools/include/jsk_topic_tools/stealth_relay.h
+++ b/jsk_topic_tools/include/jsk_topic_tools/stealth_relay.h
@@ -1,0 +1,75 @@
+// -*- mode: C++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+/*
+ * stealth_relay.h
+ * Author: Furushchev <furushchev@jsk.imi.i.u-tokyo.ac.jp>
+ */
+
+
+#ifndef STEALTH_RELAY_H__
+#define STEALTH_RELAY_H__
+
+#include <boost/thread.hpp>
+#include <nodelet/nodelet.h>
+#include <topic_tools/shape_shifter.h>
+
+
+namespace jsk_topic_tools
+{
+  class StealthRelay : public nodelet::Nodelet
+  {
+    typedef boost::shared_ptr<topic_tools::ShapeShifter const> AnyMsgConstPtr;
+  protected:
+    virtual void onInit();
+    virtual void subscribe();
+    virtual void unsubscribe();
+    virtual bool isSubscribed();
+    virtual void inputCallback(const AnyMsgConstPtr& msg);
+    virtual void timerCallback(const ros::TimerEvent& event);
+    virtual bool getNumOtherSubscribers(const std::string& name, int& num);
+
+    boost::mutex mutex_;
+    boost::shared_ptr<ros::NodeHandle> nh_, pnh_;
+    ros::Publisher pub_;
+    ros::Subscriber sub_;
+    ros::Timer poll_timer_;
+    std::string monitoring_topic_;
+    int queue_size_;
+    bool subscribed_;
+    bool advertised_;
+  };
+}
+
+#endif // STEALTH_RELAY_H__

--- a/jsk_topic_tools/jsk_topic_tools_nodelet.xml
+++ b/jsk_topic_tools/jsk_topic_tools_nodelet.xml
@@ -47,6 +47,12 @@
       relay a topic message from ~input to ~output with deprecated message.
     </description>
   </class>
+  <class name="jsk_topic_tools/StealthRelay" type="StealthRelay"
+         base_class_type="nodelet::Nodelet">
+    <description>
+      relay a topic message from ~input to ~output without incrementing subscription count.
+    </description>
+  </class>
   <class name="jsk_topic_tools/Passthrough" type="Passthrough"
          base_class_type="nodelet::Nodelet">
     <description>

--- a/jsk_topic_tools/src/stealth_relay_nodelet.cpp
+++ b/jsk_topic_tools/src/stealth_relay_nodelet.cpp
@@ -1,0 +1,159 @@
+// -*- mode: C++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+/*
+ * stealth_relay_nodelet.cpp
+ * Author: Furushchev <furushchev@jsk.imi.i.u-tokyo.ac.jp>
+ */
+
+#include <jsk_topic_tools/stealth_relay.h>
+
+
+namespace jsk_topic_tools
+{
+  void StealthRelay::onInit()
+  {
+    bool use_multithread;
+    ros::param::param<bool>("~use_multithread_callback", use_multithread, true);
+    if (use_multithread) {
+      NODELET_DEBUG("use multithread callback");
+      nh_.reset (new ros::NodeHandle (getMTNodeHandle ()));
+      pnh_.reset (new ros::NodeHandle (getMTPrivateNodeHandle ()));
+    } else {
+      NODELET_DEBUG("use singlethread callback");
+      nh_.reset (new ros::NodeHandle (getNodeHandle ()));
+      pnh_.reset (new ros::NodeHandle (getPrivateNodeHandle ()));
+    }
+
+    subscribed_ = false;
+    advertised_ = false;
+
+    pnh_->param<int>("queue_size", queue_size_, 1);
+    pnh_->param<std::string>("monitoring_topic", monitoring_topic_,
+                             pnh_->resolveName("input"));
+
+    double monitor_rate;
+    pnh_->param<double>("monitor_rate", monitor_rate, 1.0);
+    poll_timer_ = pnh_->createTimer(ros::Duration(monitor_rate),
+                                    &StealthRelay::timerCallback, this);
+
+    NODELET_DEBUG("Started monitoring %s at %.2f Hz", monitoring_topic_.c_str(), monitor_rate);
+    subscribe();
+  }
+
+  void StealthRelay::subscribe()
+  {
+    NODELET_DEBUG("subscribe");
+    sub_ = pnh_->subscribe("input", queue_size_,
+                           &StealthRelay::inputCallback, this);
+    subscribed_ = true;
+  }
+
+  void StealthRelay::unsubscribe()
+  {
+    NODELET_DEBUG("unsubscribe");
+    sub_.shutdown();
+    subscribed_ = false;
+  }
+
+  bool StealthRelay::isSubscribed()
+  {
+    return subscribed_;
+  }
+
+  void StealthRelay::inputCallback(const AnyMsgConstPtr& msg)
+  {
+    boost::mutex::scoped_lock lock(mutex_);
+
+    if (!advertised_)
+    {
+      pub_ = msg->advertise(*pnh_, "output", 1);
+      advertised_ = true;
+      unsubscribe();
+      return;
+    }
+
+    pub_.publish(msg);
+  }
+
+  void StealthRelay::timerCallback(const ros::TimerEvent& event)
+  {
+    boost::mutex::scoped_lock lock(mutex_);
+
+    if (pub_.getNumSubscribers() == 0 && subscribed_)
+    {
+      unsubscribe();
+      return;
+    }
+
+    int subscribing_num = 0;
+    if (!getNumOtherSubscribers(monitoring_topic_, subscribing_num))
+    {
+      if (subscribed_) unsubscribe();
+    }
+    else if (subscribed_ && subscribing_num == 0)
+      unsubscribe();
+    else if (!subscribed_ && subscribing_num > 0)
+      subscribe();
+  }
+
+  bool StealthRelay::getNumOtherSubscribers(const std::string& name, int& num)
+  {
+    XmlRpc::XmlRpcValue req(ros::this_node::getName()), res, data;
+    bool ok = ros::master::execute("getSystemState", req, res, data, false);
+
+    XmlRpc::XmlRpcValue& sub_info = data[1];
+    for (size_t i = 0; i < sub_info.size(); ++i)
+    {
+      std::string topic_name = sub_info[i][0];
+      if (topic_name == name)
+      {
+        XmlRpc::XmlRpcValue& subscribers = sub_info[i][1];
+        int cnt = 0;
+        for (size_t j = 0; j < subscribers.size(); ++j)
+        {
+          std::string subscriber = subscribers[j];
+          if (subscriber != ros::this_node::getName()) ++cnt;
+        }
+        num = cnt;
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
+#include <pluginlib/class_list_macros.h>
+typedef jsk_topic_tools::StealthRelay StealthRelay;
+PLUGINLIB_EXPORT_CLASS(StealthRelay, nodelet::Nodelet)

--- a/jsk_topic_tools/test/test_stealth_relay.py
+++ b/jsk_topic_tools/test/test_stealth_relay.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Author: Furushchev <furushchev@jsk.imi.i.u-tokyo.ac.jp>
+
+import rospy
+import unittest
+from std_msgs.msg import String
+
+
+class TestStealthRelay(unittest.TestCase):
+    def out_callback(self, msg):
+        self.out_msg_count += 1
+
+    def monitor_callback(self, msg):
+        self.monitor_msg_count += 1
+
+    def test_stealth_relay(self):
+        self.out_msg_count = 0
+        self.monitor_msg_count = 0
+        sub_out = rospy.Subscriber("/stealth_relay/output", String,
+                                   self.out_callback, queue_size=1)
+        for i in range(5):
+            if sub_out.get_num_connections() == 0:
+                rospy.sleep(1)
+        self.assertTrue(sub_out.get_num_connections() > 0)
+
+        rospy.sleep(5)
+        self.assertEqual(self.out_msg_count, 0)
+
+        sub_monitor = rospy.Subscriber("/original_topic/relay", String,
+                                       self.monitor_callback, queue_size=1)
+        rospy.sleep(5)
+        self.assertGreater(self.monitor_msg_count, 0)
+        self.assertGreater(self.out_msg_count, 0)
+
+        cnt = self.out_msg_count
+        sub_monitor.unregister()
+
+        rospy.sleep(3)
+        self.assertLess(abs(cnt - self.out_msg_count), 30)
+
+
+if __name__ == '__main__':
+    import rostest
+    rospy.init_node("test_stealth_relay")
+    rostest.rosrun("jsk_topic_tools", "test_stealth_relay", TestStealthRelay)

--- a/jsk_topic_tools/test/test_stealth_relay.test
+++ b/jsk_topic_tools/test/test_stealth_relay.test
@@ -1,0 +1,20 @@
+<launch>
+  <node name="topic_pub" pkg="rostopic" type="rostopic"
+        args="pub -r 30 /original_topic std_msgs/String foo" />
+  <node name="topic_relay" pkg="topic_tools" type="relay"
+        args="/original_topic /original_topic/relay">
+    <rosparam>
+      lazy: true
+    </rosparam>
+  </node>
+  <test test-name="test_stealth_relay"
+        pkg="jsk_topic_tools" type="test_stealth_relay.py" />
+
+  <node name="stealth_relay" pkg="jsk_topic_tools" type="stealth_relay"
+        output="screen">
+    <remap from="~input" to="original_topic" />
+    <rosparam>
+      monitoring_topic: /original_topic/relay
+    </rosparam>
+  </node>
+</launch>


### PR DESCRIPTION
This node relays topic from `~input` and `~output` as normal `rostopic relay`, but it does not increment number of subscribers (actually increments number of subscribers, but not looks like so)