### PR TITLE
Skip mkdir failures that can be caused by multiprocessing

### DIFF
--- a/jsk_data/src/jsk_data/download_data.py
+++ b/jsk_data/src/jsk_data/download_data.py
@@ -115,9 +115,9 @@ def download_data(pkg_name, path, url, md5, download_client=None,
             try:
                 os.makedirs(osp.dirname(path))
             except OSError as e:
-                print('\033[31mCould not make direcotry {dir} {err}\033[0m'
-                      .format(dir=osp.dirname(path), err=e))
-                return
+                # can fail on running with multiprocess
+                if not osp.isdir(path):
+                    raise
     # prepare cache dir
     if "JSK_DATA_CACHE_DIR" in os.environ:
         cache_root_dir = os.getenv("JSK_DATA_CACHE_DIR")
@@ -125,7 +125,12 @@ def download_data(pkg_name, path, url, md5, download_client=None,
         cache_root_dir = osp.join(os.getenv('ROS_HOME', osp.expanduser('~/.ros')), "data")
     cache_dir = osp.join(cache_root_dir, pkg_name)
     if not osp.exists(cache_dir):
-        os.makedirs(cache_dir)
+        try:
+            os.makedirs(cache_dir)
+        except OSError as e:
+            # can fail on running with multiprocess
+            if not osp.isdir(path):
+                raise
         if chmod:
             os.chmod(cache_dir, 0777)
     cache_file = osp.join(cache_dir, osp.basename(path))


### PR DESCRIPTION
Current implementation exits with OSError, but I'd like to pass the exception because it is an expected error.

```
Errors << jsk_apc2016_common:make /home/travis/ros/ws_jsk_apc/logs/jsk_apc2016_common/build.make.000.log
Traceback (most recent call last):
  File "/home/travis/ros/ws_jsk_apc/src/jsk_apc/jsk_apc2016_common/scripts/install_sample_data.py", line 19, in <module>
    main()
  File "/home/travis/ros/ws_jsk_apc/src/jsk_apc/jsk_apc2016_common/scripts/install_sample_data.py", line 14, in main
    extract=True,
  File "/opt/ros/indigo/lib/python2.7/dist-packages/jsk_data/download_data.py", line 119, in download_data
    os.makedirs(cache_dir)
  File "/usr/lib/python2.7/os.py", line 157, in makedirs
    mkdir(name, mode)
OSError: [Errno 17] File exists: '/home/travis/.ros/data/jsk_apc2016_common'
```