### PR TITLE
Validate implementation of child class of ConnectionBasedTransport

### DIFF
--- a/jsk_topic_tools/src/jsk_topic_tools/transport.py
+++ b/jsk_topic_tools/src/jsk_topic_tools/transport.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import abc
 import argparse
 import sys
 
@@ -18,7 +19,7 @@ NOT_SUBSCRIBED = 1
 
 # define a new metaclass which overrides the '__call__' function
 # See: http://martyalchin.com/2008/jan/10/simple-plugin-framework/
-class MetaConnectionBasedTransport(type):
+class MetaConnectionBasedTransport(abc.ABCMeta):
     def __call__(cls, *args, **kwargs):
         """Called when you call ConnectionBasedTransport()"""
         obj = type.__call__(cls, *args, **kwargs)
@@ -73,11 +74,13 @@ class ConnectionBasedTransport(rospy.SubscribeListener):
                 " child subscribers. Set '~always_subscribe' as True"
                 ' to have it subscribe always.'.format(name=rospy.get_name()))
 
+    @abc.abstractmethod
     def subscribe(self):
-        raise NotImplementedError('Please overwrite this method')
+        raise NotImplementedError
 
+    @abc.abstractmethod
     def unsubscribe(self):
-        raise NotImplementedError('Please overwrite this method')
+        raise NotImplementedError
 
     def is_subscribed(self):
         return self._connection_status == SUBSCRIBED

--- a/jsk_topic_tools/src/jsk_topic_tools/transport.py
+++ b/jsk_topic_tools/src/jsk_topic_tools/transport.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import abc
 import argparse
@@ -62,6 +61,10 @@ class ConnectionBasedTransport(rospy.SubscribeListener):
 
     def _post_init(self):
         self.is_initialized = True
+        if not self._publishers:
+            raise RuntimeError(
+                'No publishers registered.'
+                ' Have you called ConnectionBasedTransport.advertise?')
         if rospy.get_param('~always_subscribe', False):
             self.subscribe()
             self._connection_status = SUBSCRIBED


### PR DESCRIPTION
This checks some common mistakes when users implement Python node using `jsk_topic_tools.ConnectionBasedTransport`.

-  Check if publishers exist to avoid implementation failures

   Someone uses rospy.Publisher instead of ConnectionBasedTransport.advertise.


-  Use ABCMeta to avoid unexpected usage of ConnectionBasedTransport

   Someone uses this class without any subscriptions, and in that case this
   class should not be used in general. ABCMeta forces user to overwrite the abstract methods (ex. `subscribe`, `unsubscribe`).