### PR TITLE
travis: drop hydro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,8 @@ env:
     - ROS_DISTRO=indigo USE_DEB=true BEFORE_SCRIPT='$CI_SOURCE_PATH/.travis_before_script_opencv3.bash'
     - ROS_DISTRO=jade USE_DEB=true
     - ROS_DISTRO=kinetic USE_DEB=true
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: ROS_DISTRO=hydro USE_DEB=false CATKIN_TOOLS_BUILD_OPTIONS='-iv --summarize --no-status --no-color'
 script: source .travis/travis.sh


### PR DESCRIPTION
According to offline talk with @k-okada, we're now considering about dropping hydro.
If this test does not pass, only drop hydro and keep `jsk_travis` unchanged.