### PR TITLE
jsk_topic_tools: add option to display diagnostic messages on warning level

### DIFF
--- a/doc/jsk_topic_tools/class/connection_based_nodelet.md
+++ b/doc/jsk_topic_tools/class/connection_based_nodelet.md
@@ -10,6 +10,10 @@ This base-class is being deprecated and replaced by `nodelet_topic_tools::Nodele
 This class is a base-class which can start subscribing topics if published topics are subscribed by the other node.
 This is abstruct class.
 
+## Note
+
+Each subclass of this class must call `onInitPostProcess` in the last line `onInit`.
+
 ## Parameter
 - `~use_multithread_callback` (Bool, default: `true`):
 

--- a/doc/jsk_topic_tools/class/diagnostic_nodelet.md
+++ b/doc/jsk_topic_tools/class/diagnostic_nodelet.md
@@ -4,10 +4,25 @@
 
 This class is a subclass of [`ConnectionBasedNodelet`](connection_based_nodelet.html).
 Instances of this class can publish diagnostics messages.
-This is abstruct class.
+This is an abstruct class.
+
+## Note
+
+Each subclass of this class is required to call `vital_checker_->poke()` on all callback functions so that this class can check the health of the functionality of the nodelet.
 
 ## Publishing Topic
+
 - `~diagnostics` (`diagnostic_msgs::DiagnosticArray`):
+
+    Diagnostic messages
 
 ## Parameter
 - `~vital_rate` (Double, default: `0.1`):
+
+    Rate to determine if the nodelet is in health.
+    If the rate that the callback functions is below this parameter, error messages are displayed on diagnostics.
+
+- `/diagnostic_nodelet/use_warn` or `~use_warn` (Bool, default: `False`):
+
+    If this parameter is enabled, diagnostic messages on failure is displayed on `WARN` level instead of `ERROR` level.
+    `/diagnostic_nodelet/use_warn` affects every nodelets that inherits this class, but it still can be overriden for each nodelet by setting `~use_warn` parameter.

--- a/jsk_topic_tools/include/jsk_topic_tools/diagnostic_nodelet.h
+++ b/jsk_topic_tools/include/jsk_topic_tools/diagnostic_nodelet.h
@@ -110,6 +110,12 @@ namespace jsk_topic_tools
      */
     jsk_topic_tools::VitalChecker::Ptr vital_checker_;
 
+    /** @brief
+     * True if summary is displayed as 'Warnings', otherwise it is displayed as 'Errors'
+     */
+    uint8_t diagnostic_error_level_;
+    
+
   private:
     
   };

--- a/jsk_topic_tools/include/jsk_topic_tools/diagnostic_utils.h
+++ b/jsk_topic_tools/include/jsk_topic_tools/diagnostic_utils.h
@@ -58,7 +58,8 @@ namespace jsk_topic_tools
   void addDiagnosticErrorSummary(
     const std::string& string_prefix,
     jsk_topic_tools::VitalChecker::Ptr vital_checker,
-    diagnostic_updater::DiagnosticStatusWrapper& stat);
+    diagnostic_updater::DiagnosticStatusWrapper& stat,
+    const uint8_t error_level = diagnostic_msgs::DiagnosticStatus::ERROR);
 
   ////////////////////////////////////////////////////////
   // add Boolean string to stat

--- a/jsk_topic_tools/src/diagnostic_nodelet.cpp
+++ b/jsk_topic_tools/src/diagnostic_nodelet.cpp
@@ -55,6 +55,19 @@ namespace jsk_topic_tools
         &DiagnosticNodelet::updateDiagnostic,
         this,
         _1));
+
+    bool use_warn;
+    nh_->param("/diagnostic_nodelet/use_warn", use_warn, false);
+    if (pnh_->hasParam("use_warn")) {
+      pnh_->getParam("use_warn", use_warn);
+    }
+    if (use_warn)
+    {
+      diagnostic_error_level_ = diagnostic_msgs::DiagnosticStatus::ERROR;
+    } else {
+      diagnostic_error_level_ = diagnostic_msgs::DiagnosticStatus::WARN;
+    }
+
     double vital_rate;
     pnh_->param("vital_rate", vital_rate, 1.0);
     vital_checker_.reset(
@@ -72,7 +85,7 @@ namespace jsk_topic_tools
       }
       else {
         jsk_topic_tools::addDiagnosticErrorSummary(
-          name_, vital_checker_, stat);
+          name_, vital_checker_, stat, diagnostic_error_level_);
       }
     }
     else {

--- a/jsk_topic_tools/src/diagnostic_utils.cpp
+++ b/jsk_topic_tools/src/diagnostic_utils.cpp
@@ -55,10 +55,11 @@ namespace jsk_topic_tools
   void addDiagnosticErrorSummary(
     const std::string& string_prefix,
     jsk_topic_tools::VitalChecker::Ptr vital_checker,
-    diagnostic_updater::DiagnosticStatusWrapper& stat)
+    diagnostic_updater::DiagnosticStatusWrapper& stat,
+    const uint8_t error_level)
   {
     stat.summary(
-      diagnostic_msgs::DiagnosticStatus::ERROR,
+      error_level,
       (boost::format("%s not running for %f sec")
        % string_prefix % vital_checker->deadSec()).str());
   }


### PR DESCRIPTION
This PR adds `~use_warning` parameter to display diagnostic messages on warning level instead of error level on `DiagnosticNodelet`.
