### PR TITLE
[jsk_topic_tools] Fixed use_warn option

### DIFF
--- a/jsk_topic_tools/src/diagnostic_nodelet.cpp
+++ b/jsk_topic_tools/src/diagnostic_nodelet.cpp
@@ -61,7 +61,7 @@ namespace jsk_topic_tools
     if (pnh_->hasParam("use_warn")) {
       pnh_->getParam("use_warn", use_warn);
     }
-    if (use_warn)
+    if (use_warn == false)
     {
       diagnostic_error_level_ = diagnostic_msgs::DiagnosticStatus::ERROR;
     } else {

--- a/jsk_topic_tools/src/diagnostic_nodelet.cpp
+++ b/jsk_topic_tools/src/diagnostic_nodelet.cpp
@@ -61,11 +61,11 @@ namespace jsk_topic_tools
     if (pnh_->hasParam("use_warn")) {
       pnh_->getParam("use_warn", use_warn);
     }
-    if (use_warn == false)
+    if (use_warn)
     {
-      diagnostic_error_level_ = diagnostic_msgs::DiagnosticStatus::ERROR;
-    } else {
       diagnostic_error_level_ = diagnostic_msgs::DiagnosticStatus::WARN;
+    } else {
+      diagnostic_error_level_ = diagnostic_msgs::DiagnosticStatus::ERROR;
     }
 
     double vital_rate;


### PR DESCRIPTION
In this [PR](https://github.com/jsk-ros-pkg/jsk_common/pull/1585), 
default of diagnostic error level have been mistakenly changed to ```warn```.
This PR fixes warn level.

