### PR TITLE
Add reset to Timer in ConnectionBasedTransport

### DIFF
--- a/jsk_topic_tools/src/jsk_topic_tools/transport.py
+++ b/jsk_topic_tools/src/jsk_topic_tools/transport.py
@@ -2,6 +2,8 @@
 
 import abc
 import argparse
+from distutils.version import LooseVersion
+import pkg_resources
 import sys
 
 import rospy
@@ -56,12 +58,17 @@ class ConnectionBasedTransport(rospy.SubscribeListener):
         self._publishers = []
         self._ever_subscribed = False
         self._connection_status = NOT_SUBSCRIBED
-        rospy.Timer(
-            rospy.Duration(5),
-            self._warn_never_subscribed_cb,
+        kwargs = dict(
+            period=rospy.Duration(5),
+            callback=self._warn_never_subscribed_cb,
             oneshot=True,
-            reset=True,
         )
+        if (LooseVersion(pkg_resources.get_distribution('rospy').version) >=
+                LooseVersion('1.12.0')):
+            # on >=kinetic, it raises ROSTimeMovedBackwardsException
+            # when we use rosbag play --loop.
+            kwargs['reset'] = True
+        rospy.Timer(**kwargs)
 
     def _post_init(self):
         self.is_initialized = True

--- a/jsk_topic_tools/src/jsk_topic_tools/transport.py
+++ b/jsk_topic_tools/src/jsk_topic_tools/transport.py
@@ -56,8 +56,12 @@ class ConnectionBasedTransport(rospy.SubscribeListener):
         self._publishers = []
         self._ever_subscribed = False
         self._connection_status = NOT_SUBSCRIBED
-        rospy.Timer(rospy.Duration(5),
-                    self._warn_never_subscribed_cb, oneshot=True)
+        rospy.Timer(
+            rospy.Duration(5),
+            self._warn_never_subscribed_cb,
+            oneshot=True,
+            reset=True,
+        )
 
     def _post_init(self):
         self.is_initialized = True


### PR DESCRIPTION
## Why?

On Kinetic we have below error, and this PR fixes it by resetting the timer.

```
[ERROR] [1535796247.786932, 1535792085.063646]: [/get_heightmap] [sleep] ROS time moved backwards: 1.407559397s
Exception in thread Thread-4:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rospy/timer.py", line 226, in run
    r.sleep()
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rospy/timer.py", line 103, in sleep
    sleep(self._remaining(curr_time))
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rospy/timer.py", line 164, in sleep
    raise rospy.exceptions.ROSTimeMovedBackwardsException(time_jump)
ROSTimeMovedBackwardsException: ROS time moved backwards

Exception in thread Thread-4:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rospy/timer.py", line 226, in run
    r.sleep()
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rospy/timer.py", line 103, in sleep
    sleep(self._remaining(curr_time))
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rospy/timer.py", line 164, in sleep
    raise rospy.exceptions.ROSTimeMovedBackwardsException(time_jump)
ROSTimeMovedBackwardsException: ROS time moved backwards

^C[image_view-9] killing on exit
[tile_image-8] killing on exit
[get_heightmap/output/depth_view-7] killing on exit
[get_heightmap-6] killing on exit
[heightmap_frame_publisher-5] killing on exit
[bbox_to_tf-4] killing on exit
[bbox_array_to_bbox-3] killing on exit
[rosbag_play-2] killing on exit
[rosout-1] killing on exit
[master] killing on exit
shutting down processing monitor...
... shutting down processing monitor complete
done
```