### PR TITLE
stealth_relay_nodelet: fix error double free or corruption (fasttop)

### DIFF
--- a/jsk_topic_tools/include/jsk_topic_tools/stealth_relay.h
+++ b/jsk_topic_tools/include/jsk_topic_tools/stealth_relay.h
@@ -53,7 +53,6 @@ namespace jsk_topic_tools
 {
   class StealthRelay : public nodelet::Nodelet
   {
-    typedef boost::shared_ptr<topic_tools::ShapeShifter const> AnyMsgConstPtr;
     typedef StealthRelayConfig Config;
   protected:
     virtual void onInit();
@@ -61,8 +60,8 @@ namespace jsk_topic_tools
     virtual void unsubscribe();
     virtual bool isSubscribed();
     virtual void configCallback(Config& config, uint32_t level);
-    virtual void inputCallback(const ros::MessageEvent<topic_tools::ShapeShifter>& event);
-    virtual void inputCallback(const AnyMsgConstPtr& msg);
+    virtual void inputCallback(const ros::MessageEvent<topic_tools::ShapeShifter const>& event);
+    virtual void inputCallback(const boost::shared_ptr<topic_tools::ShapeShifter const>& msg);
     virtual void timerCallback(const ros::TimerEvent& event);
     virtual int getNumOtherSubscribers(const std::string& name);
 

--- a/jsk_topic_tools/src/stealth_relay_nodelet.cpp
+++ b/jsk_topic_tools/src/stealth_relay_nodelet.cpp
@@ -80,7 +80,7 @@ namespace jsk_topic_tools
   void StealthRelay::subscribe()
   {
     NODELET_DEBUG("subscribe");
-    sub_ = pnh_->subscribe<const ros::MessageEvent<topic_tools::ShapeShifter>&>
+    sub_ = pnh_->subscribe<const ros::MessageEvent<topic_tools::ShapeShifter const>&>
       ("input", queue_size_, &StealthRelay::inputCallback, this);
     subscribed_ = true;
   }
@@ -130,13 +130,13 @@ namespace jsk_topic_tools
     }
   }
 
-  void StealthRelay::inputCallback(const ros::MessageEvent<topic_tools::ShapeShifter>& event)
+  void StealthRelay::inputCallback(const ros::MessageEvent<topic_tools::ShapeShifter const>& event)
   {
-    const AnyMsgConstPtr& msg = event.getConstMessage();
+    const boost::shared_ptr<topic_tools::ShapeShifter const>& msg = event.getConstMessage();
     inputCallback(msg);
   }
 
-  void StealthRelay::inputCallback(const AnyMsgConstPtr& msg)
+  void StealthRelay::inputCallback(const boost::shared_ptr<topic_tools::ShapeShifter const>& msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
     NODELET_DEBUG("inputCallback");


### PR DESCRIPTION
Currently, copy constructor of each message is called twice on callback which causes unexpected pointer release.