### PR TITLE
standalone_complexed_nodelet: add `params` key for each nodelet

### DIFF
--- a/jsk_topic_tools/sample/standalone_complexed_nodelet/simple.launch
+++ b/jsk_topic_tools/sample/standalone_complexed_nodelet/simple.launch
@@ -1,6 +1,6 @@
 <launch>
   <node pkg="jsk_topic_tools" type="standalone_complexed_nodelet"
-        name="manager">
+        name="manager" output="screen">
     <rosparam>
       nodelets:
         - name: relay
@@ -14,11 +14,14 @@
             - from: ~input
               to: relay/output
         - name: relay3
-          type: jsk_topic_tools/Relay
+          type: jsk_topic_tools/LightweightThrottle
           remappings:
             - from: ~input
               to: relay2/output
+          params:
+          - name: update_rate
+            value: 2.0
     </rosparam>
   </node>
-  <node pkg="rostopic" type="rostopic" name="foo_pub" args="pub foo std_msgs/String '{data: foooo}' -r 1" />
+  <node pkg="rostopic" type="rostopic" name="foo_pub" args="pub foo std_msgs/String '{data: foooo}' -r 10" />
 </launch>

--- a/jsk_topic_tools/src/standalone_complexed_nodelet.cpp
+++ b/jsk_topic_tools/src/standalone_complexed_nodelet.cpp
@@ -39,15 +39,30 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
 #include <list>
-// Parameter structure is
-// nodelets:
-//   -  name: node_name
-//      type: nodelet_type
-//      remappings:
-//        - from: from_topic
-//        - to: to_topic
-//        - from: from_topic
-//        - to: to_topic
+
+/*
+   Parameter structure is
+   nodelets:
+     -  name: node_name
+        type: nodelet_type
+        remappings:
+          - from: from_topic
+            to: to_topic
+          - from: from_topic
+            to: to_topic
+        params:
+          - name: approximate_sync
+            value: true
+          - name: queue_size
+            value: 100
+     -  name: node_name2
+        type: nodelet_type2
+        if: false
+     -  name: node_name3
+        type: nodelet_type3
+        unless: false
+*/
+
 
 std::string parentName(const std::string& name)
 {
@@ -151,6 +166,25 @@ int main(int argc, char** argv)
                 ROS_FATAL("remappings should be an array");
                 return 1;
               }
+            }
+            if (onenodelet_param.hasMember("params")) {
+              if (onenodelet_param["params"].getType() != XmlRpc::XmlRpcValue::TypeArray) {
+                ROS_FATAL("params parameter must be an array");
+                return 1;
+              }
+              XmlRpc::XmlRpcValue values;
+              for (int params_i = 0; params_i < onenodelet_param["params"].size(); ++params_i) {
+                XmlRpc::XmlRpcValue oneparam = onenodelet_param["params"][params_i];
+                if (!(oneparam.getType() == XmlRpc::XmlRpcValue::TypeStruct &&
+                      oneparam.hasMember("name") && oneparam.hasMember("value"))) {
+                  ROS_FATAL("each 'params' element must be a struct which contains 'name' and 'value' fields.");
+                  return 1;
+                }
+                std::string key = oneparam["name"];
+                values[key] = oneparam["value"];
+                ROS_INFO_STREAM("setparam: " << name << "/" << key << " => " << values[key]);
+              }
+              ros::param::set(name, values);
             }
             // Done reading parmaeter for one nodelet
           


### PR DESCRIPTION
```yaml
   nodelets:
     -  name: node_name
        type: nodelet_type
        remappings:
          - from: from_topic
            to: to_topic
          - from: from_topic
            to: to_topic
        params:  # This is supported in this PR.
          - name: approximate_sync
            value: true
          - name: queue_size
            value: 100
     -  name: node_name2
        type: nodelet_type2
        if: false
     -  name: node_name3
        type: nodelet_type3
        unless: false
```