### PR TITLE
[jsk_data] Skip extracting files which already exist

### DIFF
--- a/jsk_data/src/jsk_data/download_data.py
+++ b/jsk_data/src/jsk_data/download_data.py
@@ -50,10 +50,16 @@ def extract_file(path, to_directory='.', chmod=True):
                 for member in file.namelist():
                     if not osp.exists(member):
                         extract_members.append(member)
+                    else:
+                        print('[%s] Skip extracting %s since it already exists'
+                              % (path, member))
             elif isinstance(file, tarfile.TarFile):
                 for member in file.getmembers():
                     if not osp.exists(member.path):
                         extract_members.append(member)
+                    else:
+                        print('[%s] Skip extracting %s since it already exists'
+                              % (path, member.path))
             file.extractall(members=extract_members)
             extracted_files = getnames(file)
             root_files = list(set(name.split('/')[0]

--- a/jsk_data/src/jsk_data/download_data.py
+++ b/jsk_data/src/jsk_data/download_data.py
@@ -44,7 +44,17 @@ def extract_file(path, to_directory='.', chmod=True):
     try:
         file = opener(path, mode)
         try:
-            file.extractall()
+            # Skip extracting files which already exist.
+            extract_members = []
+            if hasattr(file, 'namelist'):  # zip file
+                for member in file.namelist():
+                    if not osp.exists(member):
+                        extract_members.append(member)
+            elif hasattr(file, 'getmembers'):  # tar file
+                for member in file.getmembers():
+                    if not osp.exists(member.path):
+                        extract_members.append(member)
+            file.extractall(members=extract_members)
             extracted_files = getnames(file)
             root_files = list(set(name.split('/')[0]
                                   for name in getnames(file)))

--- a/jsk_data/src/jsk_data/download_data.py
+++ b/jsk_data/src/jsk_data/download_data.py
@@ -46,11 +46,11 @@ def extract_file(path, to_directory='.', chmod=True):
         try:
             # Skip extracting files which already exist.
             extract_members = []
-            if hasattr(file, 'namelist'):  # zip file
+            if isinstance(file, zipfile.ZipFile):
                 for member in file.namelist():
                     if not osp.exists(member):
                         extract_members.append(member)
-            elif hasattr(file, 'getmembers'):  # tar file
+            elif isinstance(file, tarfile.TarFile):
                 for member in file.getmembers():
                     if not osp.exists(member.path):
                         extract_members.append(member)


### PR DESCRIPTION
If contents of tar/zip archive already exist, `download_data` will skip extracting them by this PR.