### PR TITLE
[jsk_tools/roscore_regardless.py] Do not send SIGTERM before roslaunch sends SIGTERM

### DIFF
--- a/doc/jsk_tools/cltools/roscore_regardless.md
+++ b/doc/jsk_tools/cltools/roscore_regardless.md
@@ -10,7 +10,10 @@ rosrun jsk_tools roscore_regardless.py rostopic echo /foo
 ## Usage
 ```
 $ rosrun jsk_tools roscore_regardless.py -h
-usage: roscore_regardless.py [-h] [--respawn] [--timeout TIMEOUT] ...
+usage: roscore_regardless.py [-h] [--respawn] [--timeout TIMEOUT]
+                             [--sigint-timeout SIGINT_TIMEOUT]
+                             [--sigterm-timeout SIGTERM_TIMEOUT]
+                             ...
 
 positional arguments:
   commands
@@ -20,4 +23,10 @@ positional arguments:
     --respawn, -r      respawn if child process stops
     --timeout TIMEOUT  Timeout to verify if rosmaster is alive by ping command
                        in seconds.
+  --sigint-timeout SIGINT_TIMEOUT
+                       Timeout to escalete from sigint to sigterm to kill
+                       child processes
+  --sigterm-timeout SIGTERM_TIMEOUT
+                       Timeout to escalete from sigterm to sigkill to kill
+                       child processes
 ```


### PR DESCRIPTION
When using roscore_regardless.py with roslaunch, roscore_regardless.py may send SIGTERM to roslaunch before the roslaunch sends SIGTERM to the child processes. 
In that case, the processes invoked by roslaunch can be zombie because the parent roslaunch is killed by roscore_regardless.py.

* Add `--sigint-timeout` and `--sigterm-timeout` options to change duration to escalate signals.
* Increase default timeout values of `--sigint-timeout` and `--sigterm-timeout` from 10 seconds and 2 seconds to 20 seconds and 10 seconds respectively because they should be longer than the values in roslaunch. In roslaunch code, [`_TIMEOUT_SIGINT` is 10 seconds](https://github.com/ros/ros_comm/blob/6b9efd56d6882d1c017152ba11a5780a1496b30b/tools/roslaunch/src/roslaunch/nodeprocess.py#L58) and [`_TIMEOUT_SIGTERM` is 2 seconds.](https://github.com/ros/ros_comm/blob/6b9efd56d6882d1c017152ba11a5780a1496b30b/tools/roslaunch/src/roslaunch/nodeprocess.py#L59)