### PR TITLE
[jsk_tools] Add --ping-trials option to roscore_regardless.py

### DIFF
--- a/doc/jsk_tools/cltools/roscore_regardless.md
+++ b/doc/jsk_tools/cltools/roscore_regardless.md
@@ -11,6 +11,7 @@ rosrun jsk_tools roscore_regardless.py rostopic echo /foo
 ```
 $ rosrun jsk_tools roscore_regardless.py -h
 usage: roscore_regardless.py [-h] [--respawn] [--timeout TIMEOUT]
+                             [--ping-trials PING_TRIALS]
                              [--sigint-timeout SIGINT_TIMEOUT]
                              [--sigterm-timeout SIGTERM_TIMEOUT]
                              ...
@@ -18,15 +19,18 @@ usage: roscore_regardless.py [-h] [--respawn] [--timeout TIMEOUT]
 positional arguments:
   commands
 
-  optional arguments:
-    -h, --help         show this help message and exit
-    --respawn, -r      respawn if child process stops
-    --timeout TIMEOUT  Timeout to verify if rosmaster is alive by ping command
-                       in seconds.
+optional arguments:
+  -h, --help            show this help message and exit
+  --respawn, -r         respawn if child process stops
+  --timeout TIMEOUT     Timeout to verify if rosmaster is alive by ping
+                        command in seconds
+  --ping-trials PING_TRIALS
+                        If ping fails PING-TRIALS times, master is regarded as
+                        dead
   --sigint-timeout SIGINT_TIMEOUT
-                       Timeout to escalete from sigint to sigterm to kill
-                       child processes
+                        Timeout to escalete from sigint to sigterm to kill
+                        child processes
   --sigterm-timeout SIGTERM_TIMEOUT
-                       Timeout to escalete from sigterm to sigkill to kill
-                       child processes
+                        Timeout to escalete from sigterm to sigkill to kill
+                        child processes
 ```

--- a/jsk_tools/bin/roscore_regardless.py
+++ b/jsk_tools/bin/roscore_regardless.py
@@ -122,21 +122,24 @@ def parse_args(args):
                    help="respawn if child process stops")
     p.add_argument("--timeout", type=int, default=10,
                    help="Timeout to verify if rosmaster is alive by ping command in seconds")
+    p.add_argument("--ping-trials", type=int, default=1,
+                   help="If ping fails PING_TRIALS times, master is regarded as dead")
     p.add_argument("--sigint-timeout", type=int, default=20,
                    help="Timeout to escalete from sigint to sigterm to kill child processes")
     p.add_argument("--sigterm-timeout", type=int, default=10,
                    help="Timeout to escalete from sigterm to sigkill to kill child processes")
     args = p.parse_args()
-    return args.commands, args.respawn, args.timeout, args.sigint_timeout, args.sigterm_timeout
+    return (args.commands, args.respawn, args.timeout, args.sigint_timeout, args.sigterm_timeout,
+            args.ping_trials)
 
 
 def main(args):
-    cmds, respawn, timeout, sigint_timeout, sigterm_timeout = parse_args(args)
+    cmds, respawn, timeout, sigint_timeout, sigterm_timeout, trials = parse_args(args)
     exit_code = 0
     previous_master_state = None
     try:
         while True:
-            master_state = isMasterAlive(timeout_sec=timeout)
+            master_state = isMasterAlive(timeout_sec=timeout, trials=trials)
             if g_process_object and g_process_object.poll() is not None:
                 # Child process exited
                 pid = g_process_object.pid

--- a/jsk_topic_tools/src/jsk_topic_tools/master_util.py
+++ b/jsk_topic_tools/src/jsk_topic_tools/master_util.py
@@ -7,7 +7,7 @@ import os
 previous_run_id = None
 
 
-def isMasterAlive(timeout_sec):
+def isMasterAlive(timeout_sec, trials):
     """
     return True if master alive and return False if
     master is not alive
@@ -16,10 +16,18 @@ def isMasterAlive(timeout_sec):
     try:
         # first check the host is available
         master_host = urlparse.urlsplit(rospy.core.rosgraph.get_master_uri()).hostname
-        response = os.system("ping -W {} -c 1 {} > /dev/null".format(timeout_sec, master_host))
-        if response != 0:
-            print "master machine looks down"
-            return False
+        for i in range(trials):
+            response = os.system("ping -W {} -c 1 {} > /dev/null".format(timeout_sec, master_host))
+            if response == 0:
+                # host machine is available, immediately break from for loop
+                break
+            # Ping failed trials times in a row, the master computer is regarded as dead.
+            if i == trials - 1:
+                print "master machine looks down because ping fails with timeout={} {} times".format(timeout_sec, trials)
+                return False
+            else:
+                print "ping fails {}/{} times".format(i, trials)
+
         assert 1 == rospy.get_master().getSystemState()[0]
         run_id = rospy.get_param("/run_id")
 


### PR DESCRIPTION
* Sometimes ping is not stable. `--ping-trials` option enables
  roscore_regardless.py to verify host computer of rosmaster is alive
  by multi-times ping commands.