### PR TITLE
[jsk_topic_tools] import _pickle as pickle for python3

### DIFF
--- a/jsk_topic_tools/src/jsk_topic_tools/log_utils.py
+++ b/jsk_topic_tools/src/jsk_topic_tools/log_utils.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import cPickle as pickle
+try:
+    import cPickle as pickle
+except ImportError:
+    import _pickle as pickle
 import inspect
 
 import rosgraph

--- a/jsk_topic_tools/src/jsk_topic_tools/log_utils.py
+++ b/jsk_topic_tools/src/jsk_topic_tools/log_utils.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# cPickle is moved to _pickle in Python3
+# See https://docs.python.org/3.1/whatsnew/3.0.html#library-changes
 try:
     import cPickle as pickle
 except ImportError:


### PR DESCRIPTION
cpickle is no more used in python3