### PR TITLE
Fix download_data.py for Python3

### DIFF
--- a/jsk_data/src/jsk_data/download_data.py
+++ b/jsk_data/src/jsk_data/download_data.py
@@ -70,7 +70,7 @@ def extract_file(path, to_directory='.', chmod=True):
         if chmod:
             for fname in extracted_files:
                 if not is_file_writable(fname):
-                    os.chmod(os.path.abspath(fname), 0777)
+                    os.chmod(os.path.abspath(fname), 0o777)
         os.chdir(cwd)
     print('[%s] Finished extracting to %s' % (path, to_directory))
     return root_files
@@ -86,10 +86,10 @@ def decompress_rosbag(path, quiet=False, chmod=True):
     finally:
         if chmod:
             if not is_file_writable(path):
-                os.chmod(path, 0777)
+                os.chmod(path, 0o777)
             orig_path = osp.splitext(path)[0] + '.orig.bag'
             if not is_file_writable(orig_path):
-                os.chmod(orig_path, 0777)
+                os.chmod(orig_path, 0o777)
     print('[%s] Finished decompressing the rosbag' % path)
 
 
@@ -104,7 +104,7 @@ def download(client, url, output, quiet=False, chmod=True):
     finally:
         if chmod:
             if not is_file_writable(output):
-                os.chmod(output, 0766)
+                os.chmod(output, 0o766)
     print('[%s] Finished downloading' % output)
 
 
@@ -189,7 +189,7 @@ def download_data(pkg_name, path, url, md5, download_client=None,
         finally:
             if chmod:
                 if not is_file_writable(cache_dir):
-                    os.chmod(cache_dir, 0777)
+                    os.chmod(cache_dir, 0o777)
     cache_file = osp.join(cache_dir, osp.basename(path))
 
     # check if cache exists, and update if necessary


### PR DESCRIPTION
## Why?

```
process[data_collection_server-5]: started with pid [11865]
Traceback (most recent call last):
  File "/home/wkentaro/xxxxxxxxxxx/src/jsk-ros-pkg/jsk_common/jsk_data/node_scripts/data_collection_server.py", line 26, in <module>
    from jsk_data.cfg import DataCollectionServerConfig
  File "/home/wkentaro/xxxxxxxxxxx/devel/lib/python3/dist-packages/jsk_data/__init__.py", line 35, in <module>
    exec(__fh.read())
  File "<string>", line 1, in <module>
  File "/home/wkentaro/xxxxxxxxxxx/src/jsk-ros-pkg/jsk_common/jsk_data/src/jsk_data/download_data.py", line 73
    os.chmod(os.path.abspath(fname), 0777)
                                        ^
SyntaxError: invalid token
```