### PR TITLE
[jsk_topic_tools/SynchronizedThrottle] Reset sync policy in destructor

### DIFF
--- a/jsk_topic_tools/include/jsk_topic_tools/synchronized_throttle.h
+++ b/jsk_topic_tools/include/jsk_topic_tools/synchronized_throttle.h
@@ -180,6 +180,7 @@ class SynchronizedThrottle : public nodelet::Nodelet
   static const int MAX_SYNC_NUM = 8;
 
  protected:
+  virtual ~SynchronizedThrottle();
   virtual void onInit();
   virtual void configCallback(Config &config, uint32_t level);
   virtual void subscribe();

--- a/jsk_topic_tools/src/synchronized_throttle_nodelet.cpp
+++ b/jsk_topic_tools/src/synchronized_throttle_nodelet.cpp
@@ -101,6 +101,19 @@ void SynchronizedThrottle::onInit()
   }
 }
 
+SynchronizedThrottle::~SynchronizedThrottle() {
+  // This fixes the following error on shutdown of the nodelet:
+  // terminate called after throwing an instance of
+  // 'boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::lock_error> >'
+  //     what():  boost: mutex lock failed in pthread_mutex_lock: Invalid argument
+  // Also see ros/ros_comm#720 .
+  if (approximate_sync_) {
+    async_.reset();
+  } else {
+    sync_.reset();
+  }
+}
+
 void SynchronizedThrottle::configCallback(Config &config, uint32_t level)
 {
   boost::mutex::scoped_lock lock(mutex_);


### PR DESCRIPTION
In SynchronizedThrottle, if node is killed, the following error occurs.
```
terminate called after throwing an instance of 'boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::lock_error> >'
  what():  boost: mutex lock failed in pthread_mutex_lock: Invalid argument
Aborted
```
This PR fixes this behavior.
Also see https://github.com/ros/ros_comm/issues/720 .