### PR TITLE
Add sample code for image_view2

### DIFF
--- a/jsk_ros_patch/image_view2/README.md
+++ b/jsk_ros_patch/image_view2/README.md
@@ -207,3 +207,15 @@ string text
 bool left_up_origin
 bool ratio_scale
 ```
+
+Sample
+------
+
+You can run the sample code of `image_view2`
+
+```bash
+# Launch image_view2 with interactive mode
+roslaunch image_view2 sample_rectangle_mouse_event.launch
+# Add markers
+rosrun image_view2 test-imageview2.l
+```

--- a/jsk_ros_patch/image_view2/sample/sample_rectangle_mouse_event.launch
+++ b/jsk_ros_patch/image_view2/sample/sample_rectangle_mouse_event.launch
@@ -1,0 +1,31 @@
+<launch>
+
+  <arg name="gui" default="true" />
+
+  <node name="camera_0"
+        pkg="image_view2" type="publish_lena.py">
+    <remap from="image" to="~image" />
+  </node>
+  <node name="camera_1"
+        pkg="image_view2" type="publish_lena.py">
+    <remap from="image" to="~image" />
+  </node>
+
+  <node name="image_view2_0"
+        pkg="image_view2" type="image_view2">
+    <remap from="image" to="camera_0/image" />
+    <rosparam subst_value="true">
+      interaction_mode: rectangle
+      use_window: $(arg gui)
+    </rosparam>
+  </node>
+  <node name="image_view2_1"
+        pkg="image_view2" type="image_view2">
+    <remap from="image" to="camera_1/image" />
+    <rosparam subst_value="true">
+      interaction_mode: rectangle
+      use_window: $(arg gui)
+    </rosparam>
+  </node>
+
+</launch>

--- a/jsk_ros_patch/image_view2/test/rectangle_mouse_event.launch
+++ b/jsk_ros_patch/image_view2/test/rectangle_mouse_event.launch
@@ -1,30 +1,8 @@
 <launch>
 
-  <node name="camera_0"
-        pkg="image_view2" type="publish_lena.py">
-    <remap from="image" to="~image" />
-  </node>
-  <node name="camera_1"
-        pkg="image_view2" type="publish_lena.py">
-    <remap from="image" to="~image" />
-  </node>
-
-  <node name="image_view2_0"
-        pkg="image_view2" type="image_view2">
-    <remap from="image" to="camera_0/image" />
-    <rosparam>
-      interaction_mode: rectangle
-      use_window: false
-    </rosparam>
-  </node>
-  <node name="image_view2_1"
-        pkg="image_view2" type="image_view2">
-    <remap from="image" to="camera_1/image" />
-    <rosparam>
-      interaction_mode: rectangle
-      use_window: false
-    </rosparam>
-  </node>
+  <include file="$(find image_view2)/sample/sample_rectangle_mouse_event.launch" >
+    <arg name="gui" value="false" />
+  </include>
 
   <node name="publish_mouse_event"
         pkg="image_view2" type="publish_mouse_event.py">


### PR DESCRIPTION
In this pull request, I did
- separate `test/rectangle_mouse_event.launch` into sample launch and test launch.
- update README about the sample launch

I think sample launch file is needed for image_view2 beginners.
We can easily understand `Interactive Modes` and `image_view2/ImageMarker2`

Interactive Modes
![output3](https://user-images.githubusercontent.com/19769486/81826097-6023f100-9572-11ea-99b4-4ca3e6ed96fb.png)

`image_view2/ImageMarker2`
![output2](https://user-images.githubusercontent.com/19769486/81806985-34940d00-9558-11ea-8669-a2c3669c86a2.png)
