### PR TITLE
[jsk_data] use xacro instead of xacro.py

### DIFF
--- a/jsk_data/launch/pr2_play.launch
+++ b/jsk_data/launch/pr2_play.launch
@@ -14,7 +14,7 @@
   <!-- set params for rviz -->
   <param name="use_sim_time" value="true" />
   <param name="bagfile_names" value="$(arg bagfile_names)"/>
-  <param if="$(arg launch_robot_model)" name="robot_description" command="$(find xacro)/xacro.py '$(find pr2_description)/robots/pr2.urdf.xacro'" />
+  <param if="$(arg launch_robot_model)" name="robot_description" command="$(find xacro)/xacro '$(find pr2_description)/robots/pr2.urdf.xacro'" />
 
   <node name="relay_kinect_head_depth_rect"
         pkg="nodelet" type="nodelet"


### PR DESCRIPTION
with this PR, we switch to use `xacro` instead of `xacro.py`.
in noetic, `xacro.py` is removed because it is deprecated.
https://github.com/ros/xacro/pull/239

this causes travis build error on noetic test.
https://travis-ci.org/github/jsk-ros-pkg/jsk_common/jobs/737033859

```
++ catkin_test_results --verbose --all build

Skipping "catkin_tools_prebuild/package.xml": the root tag is neither 'testsuite' nor 'testsuites'

Full test results for 'jsk_data/test_results/jsk_data/roslaunch-check_launch_pr2_play.launch.xml'

-------------------------------------------------

<testsuite tests="1" failures="1" time="1" errors="0" name="roslaunch-check_launch_pr2_play.launch.xml"><testcase name="jsk_data_launch_pr2_play_launch" status="run" time="1" classname="roslaunch.RoslaunchCheck"><failure message="roslaunch check [/home/travis/ros/ws_jsk_common/src/jsk_common/jsk_data/launch/pr2_play.launch] failed" type="" /></testcase><system-out>&lt;![CDATA[

[/home/travis/ros/ws_jsk_common/src/jsk_common/jsk_data/launch/pr2_play.launch]:

	Invalid &lt;param&gt; tag: Cannot load command parameter [robot_description]: no such command [['/opt/ros/noetic/share/xacro/xacro.py', '/opt/ros/noetic/share/pr2_description/robots/pr2.urdf.xacro']]. 

Param xml is &lt;param if="$(arg launch_robot_model)" name="robot_description" command="$(find xacro)/xacro.py '$(find pr2_description)/robots/pr2.urdf.xacro'"/&gt;

]]&gt;</system-out></testsuite>

-------------------------------------------------

image_view2/test_results/image_view2/rostest-test_rectangle_mouse_event.xml: 1 tests

image_view2/test_results/image_view2/rosunit-image_view2_topics.xml: 1 tests

jsk_data/test_results/jsk_data/nosetests-src.jsk_data.tests.xml: 1 tests

jsk_data/test_results/jsk_data/roslaunch-check_launch_hrp2_record.launch.xml: 1 tests

jsk_data/test_results/jsk_data/roslaunch-check_launch_pr2_play.launch.xml: 1 tests, 0 errors, 1 failures, 0 skipped

jsk_data/test_results/jsk_data/roslaunch-check_launch_urata_record.launch.xml: 1 tests

jsk_data/test_results/jsk_data/roslint-jsk_data.xml: 1 tests

jsk_data/test_results/jsk_data/rostest-tests_data_collection_server.xml: 1 tests

jsk_data/test_results/jsk_data/rosunit-test_data_collection_server.xml: 3 tests

jsk_tools/test_results/jsk_tools/roslint-jsk_tools.xml: 1 tests

jsk_tools/test_results/jsk_tools/rostest-test_python_sanity_lib.xml: 1 tests

jsk_tools/test_results/jsk_tools/rostest-test_test_rosparam_set.xml: 1 tests

jsk_tools/test_results/jsk_tools/rostest-test_test_stdout.xml: 1 tests

jsk_tools/test_results/jsk_tools/rostest-test_test_topic_published.xml: 1 tests

jsk_tools/test_results/jsk_tools/rosunit-test_rosparam_set.xml: 1 tests

jsk_tools/test_results/jsk_tools/rosunit-test_sanity_lib.xml: 3 tests

jsk_tools/test_results/jsk_tools/rosunit-test_stdout.xml: 1 tests

jsk_tools/test_results/jsk_tools/rosunit-test_topic_published.xml: 1 tests

jsk_tools/test_results/jsk_tools/shell-test_echo_testing_jsk_tools_add_shell_test.xml: 1 tests

jsk_topic_tools/test_results/jsk_topic_tools/gtest-test_rosparam_utils.xml: 2 tests

jsk_topic_tools/test_results/jsk_topic_tools/nosetests-src.jsk_topic_tools.tests.xml: 9 tests

jsk_topic_tools/test_results/jsk_topic_tools/rostest-test_test_block.xml: 1 tests

jsk_topic_tools/test_results/jsk_topic_tools/rostest-test_test_connection_based_nodelet.xml: 1 tests

jsk_topic_tools/test_results/jsk_topic_tools/rostest-test_test_connection_based_transport.xml: 1 tests

jsk_topic_tools/test_results/jsk_topic_tools/rostest-test_test_hz_measure.xml: 1 tests

jsk_topic_tools/test_results/jsk_topic_tools/rostest-test_test_lightweight_throttle.xml: 1 tests

jsk_topic_tools/test_results/jsk_topic_tools/rostest-test_test_log_utils.xml: 1 tests

jsk_topic_tools/test_results/jsk_topic_tools/rostest-test_test_nodelet_log_utils.xml: 1 tests

jsk_topic_tools/test_results/jsk_topic_tools/rostest-test_test_pose_stamped_publisher.xml: 1 tests

jsk_topic_tools/test_results/jsk_topic_tools/rostest-test_test_standalone_complexed_nodelet.xml: 1 tests

jsk_topic_tools/test_results/jsk_topic_tools/rostest-test_test_stealth_relay.xml: 1 tests

jsk_topic_tools/test_results/jsk_topic_tools/rostest-test_test_synchronized_throttle.xml: 1 tests

jsk_topic_tools/test_results/jsk_topic_tools/rostest-test_test_topic_buffer.xml: 3 tests

jsk_topic_tools/test_results/jsk_topic_tools/rostest-test_test_topic_buffer_close_wait.xml: 1 tests

jsk_topic_tools/test_results/jsk_topic_tools/rostest-test_test_topic_buffer_fixed_rate.xml: 3 tests

jsk_topic_tools/test_results/jsk_topic_tools/rostest-test_test_topic_buffer_fixed_rate_and_update_rate.xml: 3 tests

jsk_topic_tools/test_results/jsk_topic_tools/rostest-test_test_topic_buffer_update_rate.xml: 3 tests

jsk_topic_tools/test_results/jsk_topic_tools/rostest-test_test_topic_compare.xml: 1 tests

jsk_topic_tools/test_results/jsk_topic_tools/rosunit-hztest_chatter.xml: 1 tests

jsk_topic_tools/test_results/jsk_topic_tools/rosunit-hztest_chatter_buffer.xml: 1 tests

jsk_topic_tools/test_results/jsk_topic_tools/rosunit-hztest_chatter_update.xml: 1 tests

jsk_topic_tools/test_results/jsk_topic_tools/rosunit-hztest_lightweight_throttle.xml: 1 tests

jsk_topic_tools/test_results/jsk_topic_tools/rosunit-kill_buffer_server.xml: 1 tests

jsk_topic_tools/test_results/jsk_topic_tools/rosunit-test_block.xml: 2 tests

jsk_topic_tools/test_results/jsk_topic_tools/rosunit-test_connection.xml: 2 tests

jsk_topic_tools/test_results/jsk_topic_tools/rosunit-test_hz_measure.xml: 1 tests

jsk_topic_tools/test_results/jsk_topic_tools/rosunit-test_log_utils.xml: 6 tests

jsk_topic_tools/test_results/jsk_topic_tools/rosunit-test_nodelet_log_utils.xml: 2 tests

jsk_topic_tools/test_results/jsk_topic_tools/rosunit-test_pose_stamped_publisher.xml: 1 tests

jsk_topic_tools/test_results/jsk_topic_tools/rosunit-test_standalone_complexed_nodelet.xml: 1 tests

jsk_topic_tools/test_results/jsk_topic_tools/rosunit-test_stealth_relay.xml: 1 tests

jsk_topic_tools/test_results/jsk_topic_tools/rosunit-test_synchronized_throttle.xml: 4 tests

jsk_topic_tools/test_results/jsk_topic_tools/rosunit-topic_compare_test.xml: 2 tests

Summary: 86 tests, 0 errors, 1 failures, 0 skipped
```
