### PR TITLE
[jsk_network_tools] add skip_interfaces param in network_status.py

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -25,3 +25,4 @@ ROS Packages:
    jsk_data/index
    jsk_tools/index
    jsk_topic_tools/index
+   jsk_network_tools/index

--- a/doc/jsk_network_tools/index.rst
+++ b/doc/jsk_network_tools/index.rst
@@ -1,0 +1,12 @@
+=================
+jsk_network_tools
+=================
+
+This ROS package includes JSK network tools.
+
+.. toctree::
+   :glob:
+   :maxdepth: 1
+   :caption: scripts
+
+   ./scripts/*

--- a/doc/jsk_network_tools/scripts/network_status.md
+++ b/doc/jsk_network_tools/scripts/network_status.md
@@ -1,0 +1,103 @@
+# network_status.py
+
+Publish network status
+
+```bash
+$ rostopic list
+/ecublens/docker0/receive
+/ecublens/docker0/receive_kbps
+/ecublens/docker0/receive_mbps
+/ecublens/docker0/transmit
+/ecublens/docker0/transmit_kbps
+/ecublens/docker0/transmit_mbps
+/ecublens/eno1/receive
+/ecublens/eno1/receive_kbps
+/ecublens/eno1/receive_mbps
+/ecublens/eno1/transmit
+/ecublens/eno1/transmit_kbps
+/ecublens/eno1/transmit_mbps
+/ecublens/eno2/receive
+/ecublens/eno2/receive_kbps
+/ecublens/eno2/receive_mbps
+/ecublens/eno2/transmit
+/ecublens/eno2/transmit_kbps
+/ecublens/eno2/transmit_mbps
+/ecublens/lo/receive
+/ecublens/lo/receive_kbps
+/ecublens/lo/receive_mbps
+/ecublens/lo/transmit
+/ecublens/lo/transmit_kbps
+/ecublens/lo/transmit_mbps
+/ecublens/nonlocal/receive
+/ecublens/nonlocal/receive_kbps
+/ecublens/nonlocal/receive_mbps
+/ecublens/nonlocal/transmit
+/ecublens/nonlocal/transmit_kbps
+/ecublens/nonlocal/transmit_mbps
+```
+
+## Publishing Topics
+
+* `/<host name>/<interface name>/receive`
+
+  Amount of receiving data by the interface in bps
+
+* `/<host name>/<interface name>/receive_kbps`
+
+  Amount of receiving data by the interface in Kbps
+
+* `/<host name>/<interface name>/receive_mbps`
+
+  Amount of receiving data by the interface in Mbps
+
+* `/<host name>/<interface name>/transmit`
+
+  Amount of transmitting data by the interface in bps
+
+* `/<host name>/<interface name>/transmit_kbps`
+
+  Amount of transmitting data by the interface in Kbps
+
+* `/<host name>/<interface name>/transmit_mbps`
+
+  Amount of transmitting data by the interface in Mbps
+
+* `/<host name>/nonlocal/receive`
+
+  Amount of receiving data by the non-local interfaces in bps
+
+* `/<host name>/nonlocal/receive_kbps`
+
+  Amount of receiving data by the non-local interfaces in Kbps
+
+* `/<host name>/nonlocal/receive_mbps`
+
+  Amount of receiving data by the non-local interfaces in Mbps
+
+* `/<host name>/nonlocal/transmit`
+
+  Amount of transmitting data by the non-local interfaces in bps
+
+* `/<host name>/nonlocal/transmit_kbps`
+
+  Amount of transmitting data by the non-local interfaces in Kbps
+
+* `/<host name>/nonlocal/transmit_mbps`
+
+  Amount of transmitting data by the non-local interfaces in Mbps
+
+## Parameters
+
+* `~hz` (`float`, default: `10`)
+
+  Publish frequency
+
+* `~skip_interfaces` (`List of string`, default: `None`)
+
+  List of skipping interface names
+
+## Usage
+
+```bash
+rosrun jsk_network_tools network_status.py
+```

--- a/jsk_network_tools/scripts/network_status.py
+++ b/jsk_network_tools/scripts/network_status.py
@@ -13,6 +13,7 @@ class NetworkStatus():
         rospy.init_node('network')
         self.match_face = re.compile('(.+):(.*)')
         self.hz = rospy.get_param('~hz', 10)
+        self.skip_interfaces = rospy.get_param('~skip_interfaces', None)
         rospy.logdebug('publish network status (bps) at ' +  str(self.hz) + 'Hz')
         rospy.logdebug('usage:\n$rosrun jsk_network_tools network_status.py _hz:=[Hz]')
         self.init_publisher()
@@ -48,7 +49,6 @@ class NetworkStatus():
             self.faces_map[face[0]]["receive"] = {"publisher": pub_receive, "value": queue_reveice,
                                                   "publisher_kbps": pub_receive_kbps,
                                                   "publisher_mbps": pub_receive_mbps}
-
     def publish(self, event):
         faces = self.read_net_file()
         non_local_transmit = 0
@@ -83,7 +83,10 @@ class NetworkStatus():
             match = self.match_face.match(s)
             if match:
                 nums = match.group(2).split()
-                ret.append([match.group(1).strip(), nums[8], nums[0]])
+                name = match.group(1).strip()
+                if (self.skip_interfaces is None
+                        or name not in self.skip_interfaces):
+                    ret.append([name, nums[8], nums[0]])
         return ret
 
 if __name__ == '__main__':


### PR DESCRIPTION
this PR adds `~skip_interfaces` param in `jsk_network_tools/network_status.py`
You can specify skipping interfaces as follows:

```xml
<launch>
  <node name="network_status" pkg="jsk_network_tools" type="network_status.py">
    <rosparam>
      skip_interfaces:
        - docker0
        - lo
        - eno2
    </rosparam>
  </node>
</launch>
```

I also add doc for `jsk_network_tools/network_status.py`

![network_status](https://user-images.githubusercontent.com/9300063/99803163-519b3f80-2b7c-11eb-9ad8-54c03f84cbc2.png)