### PR TITLE
[jsk_topic_tools] add NODELET_VERSION_MINIMUM and fix nodelet version to build properly

### DIFF
--- a/jsk_topic_tools/CMakeLists.txt
+++ b/jsk_topic_tools/CMakeLists.txt
@@ -23,6 +23,11 @@ find_package(catkin REQUIRED COMPONENTS
   tf
   topic_tools
 )
+
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/jsk_topic_tools/nodelet_version.h.in
+  ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION}/jsk_topic_tools/nodelet_version.h)
+
 catkin_python_setup()
 add_message_files(
   FILES TopicInfo.msg

--- a/jsk_topic_tools/include/jsk_topic_tools/connection_based_nodelet.h
+++ b/jsk_topic_tools/include/jsk_topic_tools/connection_based_nodelet.h
@@ -41,7 +41,6 @@
 #include <nodelet/nodelet.h>
 #include <boost/thread.hpp>
 #include <image_transport/image_transport.h>
-#include <jsk_topic_tools/nodelet_version.h>
 #include "jsk_topic_tools/log_utils.h"
 
 namespace jsk_topic_tools
@@ -151,14 +150,12 @@ namespace jsk_topic_tools
      */
     virtual bool isSubscribed();
 
-#if NODELET_VERSION_MINIMUM(1, 9, 11)
     /** @brief warn if there are expected remappings.
     *
     * @param[in] names Names which are expected to remapped.
     * @return false if there is at least a topic which is not remapped, else true;
     */
     virtual bool warnNoRemap(const std::vector<std::string> names);
-#endif
 
     /** @brief
      * Advertise a topic and watch the publisher. Publishers which are

--- a/jsk_topic_tools/include/jsk_topic_tools/connection_based_nodelet.h
+++ b/jsk_topic_tools/include/jsk_topic_tools/connection_based_nodelet.h
@@ -41,6 +41,7 @@
 #include <nodelet/nodelet.h>
 #include <boost/thread.hpp>
 #include <image_transport/image_transport.h>
+#include <jsk_topic_tools/nodelet_version.h>
 #include "jsk_topic_tools/log_utils.h"
 
 namespace jsk_topic_tools
@@ -150,7 +151,7 @@ namespace jsk_topic_tools
      */
     virtual bool isSubscribed();
 
-#if nodelet_VERSION_MINOR > 9 || (nodelet_VERSION_MINOR == 9 && nodelet_VERSION_PATCH >= 11)
+#if NODELET_VERSION_MINIMUM(1, 9, 11)
     /** @brief warn if there are expected remappings.
     *
     * @param[in] names Names which are expected to remapped.

--- a/jsk_topic_tools/include/jsk_topic_tools/nodelet_version.h.in
+++ b/jsk_topic_tools/include/jsk_topic_tools/nodelet_version.h.in
@@ -1,0 +1,48 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Shingo Kitagawa and JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#ifndef JSK_TOPIC_TOOLS_NODELET_VERSION_
+#define JSK_TOPIC_TOOLS_NODELET_VERSION_
+
+#define NODELET_VERSION_MAJOR @nodelet_VERSION_MAJOR@
+#define NODELET_VERSION_MINOR @nodelet_VERSION_MINOR@
+#define NODELET_VERSION_PATCH @nodelet_VERSION_PATCH@
+#define NODELET_VERSION_COMBINED(major, minor, patch) (((major) << 20) | ((minor) << 10) | (patch))
+#define NODELET_VERSION NODELET_VERSION_COMBINED(NODELET_VERSION_MAJOR, NODELET_VERSION_MINOR, NODELET_VERSION_PATCH)
+
+#define NODELET_VERSION_GE(major1, minor1, patch1, major2, minor2, patch2) (NODELET_VERSION_COMBINED(major1, minor1, patch1) >= NODELET_VERSION_COMBINED(major2, minor2, patch2))
+#define NODELET_VERSION_MINIMUM(major, minor, patch) NODELET_VERSION_GE(NODELET_VERSION_MAJOR, NODELET_VERSION_MINOR, NODELET_VERSION_PATCH, major, minor, patch)
+
+#endif

--- a/jsk_topic_tools/package.xml
+++ b/jsk_topic_tools/package.xml
@@ -24,7 +24,7 @@
   <build_depend>geometry_msgs</build_depend>
   <build_depend>image_transport</build_depend>
   <build_depend>message_generation</build_depend>
-  <build_depend version_gte="1.9.11">nodelet</build_depend>
+  <build_depend>nodelet</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>roslaunch</build_depend>
   <build_depend>rosnode</build_depend>
@@ -45,7 +45,7 @@
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>image_transport</exec_depend>
   <exec_depend>message_runtime</exec_depend>
-  <exec_depend version_gte="1.9.11">nodelet</exec_depend>
+  <exec_depend>nodelet</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-opencv</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-opencv</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</exec_depend>

--- a/jsk_topic_tools/src/connection_based_nodelet.cpp
+++ b/jsk_topic_tools/src/connection_based_nodelet.cpp
@@ -108,12 +108,12 @@ namespace jsk_topic_tools
     }
   }
 
-#if NODELET_VERSION_MINIMUM(1, 9, 11)
   bool ConnectionBasedNodelet::warnNoRemap(const std::vector<std::string> names)
   {
     bool no_warning = true;
     // standalone
     ros::M_string remappings = ros::names::getRemappings();
+#if NODELET_VERSION_MINIMUM(1, 9, 11)
     // load
     ros::M_string remappings_loaded = getRemappingArgs();
     for (ros::M_string::iterator it = remappings_loaded.begin();
@@ -121,6 +121,7 @@ namespace jsk_topic_tools
     {
       remappings[it->first] = it->second;
     }
+#endif
     for (size_t i = 0; i < names.size(); i++)
     {
       std::string resolved_name = ros::names::resolve(/*name=*/names[i],
@@ -133,7 +134,6 @@ namespace jsk_topic_tools
     }
     return no_warning;
   }
-#endif
 
   void ConnectionBasedNodelet::connectionCallback(const ros::SingleSubscriberPublisher& pub)
   {

--- a/jsk_topic_tools/src/connection_based_nodelet.cpp
+++ b/jsk_topic_tools/src/connection_based_nodelet.cpp
@@ -33,6 +33,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
+#include <jsk_topic_tools/nodelet_version.h>
 #include "jsk_topic_tools/connection_based_nodelet.h"
 #include "jsk_topic_tools/log_utils.h"
 
@@ -107,7 +108,7 @@ namespace jsk_topic_tools
     }
   }
 
-#if nodelet_VERSION_MINOR > 9 || (nodelet_VERSION_MINOR == 9 && nodelet_VERSION_PATCH >= 11)
+#if NODELET_VERSION_MINIMUM(1, 9, 11)
   bool ConnectionBasedNodelet::warnNoRemap(const std::vector<std::string> names)
   {
     bool no_warning = true;

--- a/jsk_topic_tools/src/connection_based_nodelet.cpp
+++ b/jsk_topic_tools/src/connection_based_nodelet.cpp
@@ -111,9 +111,9 @@ namespace jsk_topic_tools
   bool ConnectionBasedNodelet::warnNoRemap(const std::vector<std::string> names)
   {
     bool no_warning = true;
+#if NODELET_VERSION_MINIMUM(1, 9, 11)
     // standalone
     ros::M_string remappings = ros::names::getRemappings();
-#if NODELET_VERSION_MINIMUM(1, 9, 11)
     // load
     ros::M_string remappings_loaded = getRemappingArgs();
     for (ros::M_string::iterator it = remappings_loaded.begin();
@@ -121,7 +121,6 @@ namespace jsk_topic_tools
     {
       remappings[it->first] = it->second;
     }
-#endif
     for (size_t i = 0; i < names.size(); i++)
     {
       std::string resolved_name = ros::names::resolve(/*name=*/names[i],
@@ -132,6 +131,7 @@ namespace jsk_topic_tools
         no_warning = false;
       }
     }
+#endif
     return no_warning;
   }
 


### PR DESCRIPTION
THIS IS URGENT.

This PR fixes build error in `ConnectionBasedNodelet` introduced in #1647 .
It was totally my misunderstanding about cmake and build system.
I fix it to build properly, and I also check the method exists in `libjsk_topic_tools.so`.

## UPDATE

I add `jsk_topic_tools/nodelet_version.h` to check nodelet version in `jsk_topic_tools`.

## `2.2.10`

`warnNoRemap` exists

```
[knorth55][melodic-p50][/opt/ros/melodic/lib]
$ dpkg -l | grep jsk-topic-tools
ii  ros-melodic-jsk-topic-tools                                      2.2.10-0bionic.20200402.152204                   amd64        jsk_topic_tools
[knorth55][melodic-p50][/opt/ros/melodic/lib]
$ nm -gD libjsk_topic_tools.so | grep connectionbasednodelet -i | grep warn
00000000001217e0 T _ZN15jsk_topic_tools22ConnectionBasedNodelet11warnNoRemapESt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EE
000000000011e8b0 T _ZN15jsk_topic_tools22ConnectionBasedNodelet27warnNeverSubscribedCallbackERKN3ros14WallTimerEventE
000000000011eb60 T _ZN15jsk_topic_tools22ConnectionBasedNodelet35warnOnInitPostProcessCalledCallbackERKN3ros14WallTimerEventE
```

## `2.2.11`

`warnNoRemap` does not exist.

```
[knorth55][melodic-p50][/opt/ros/melodic/lib]
$ dpkg -l | grep jsk-topic-tools
ii  ros-melodic-jsk-topic-tools                                      2.2.11-1bionic.20201022.175149                   amd64        jsk_topic_tools
[knorth55][melodic-p50][/opt/ros/melodic/lib]
$ nm -gD libjsk_topic_tools.so | grep connectionbasednodelet -i | grep warn
000000000011d660 T _ZN15jsk_topic_tools22ConnectionBasedNodelet27warnNeverSubscribedCallbackERKN3ros14WallTimerEventE
000000000011d3b0 T _ZN15jsk_topic_tools22ConnectionBasedNodelet35warnOnInitPostProcessCalledCallbackERKN3ros14WallTimerEventE
```

## Current master

`warnNoRemap` does not exist.

```
[knorth55][melodic-p50][~/ros/melodic/devel/.private/jsk_topic_tools/lib]
$ nm -gD libjsk_topic_tools.so | grep connectionbasednodelet -i | grep warn
00000000003d0e26 T _ZN15jsk_topic_tools22ConnectionBasedNodelet27warnNeverSubscribedCallbackERKN3ros14WallTimerEventE
00000000003d0be6 T _ZN15jsk_topic_tools22ConnectionBasedNodelet35warnOnInitPostProcessCalledCallbackERKN3ros14WallTimerEventE
```

## This PR

`warnNoRemap` exist.

```
[knorth55][melodic-p50][~/ros/melodic/devel/.private/jsk_topic_tools/lib]
$ nm -gD libjsk_topic_tools.so | grep connectionbasednodelet -i | grep warnNoRemap
00000000003d1df6 T _ZN15jsk_topic_tools22ConnectionBasedNodelet11warnNoRemapESt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EE
00000000003d1bb6 T _ZN15jsk_topic_tools22ConnectionBasedNodelet27warnNeverSubscribedCallbackERKN3ros14WallTimerEventE
00000000003d1976 T _ZN15jsk_topic_tools22ConnectionBasedNodelet35warnOnInitPostProcessCalledCallbackERKN3ros14WallTimerEventE
```

