### PR TITLE
add audio_video_recorder in jsk_common

### DIFF
--- a/audio_video_recorder/CMakeLists.txt
+++ b/audio_video_recorder/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 2.8.3)
+
+project(audio_video_recorder)
+
+find_package(catkin REQUIRED COMPONENTS roscpp audio_common_msgs sensor_msgs)
+
+find_package(PkgConfig)
+pkg_check_modules(GST1.0 gstreamer-1.0 REQUIRED)
+
+find_package(Boost REQUIRED COMPONENTS thread)
+
+catkin_package(
+  INCLUDE_DIRS include
+  CATKIN_DEPENDS
+  roscpp
+  audio_common_msgs
+  message_filters
+  sensor_msgs
+)
+
+include_directories(include
+    ${catkin_INCLUDE_DIRS}
+    ${Boost_INCLUDE_DIRS}
+    ${GST1.0_INCLUDE_DIRS}
+)
+
+add_executable(audio_video_recorder src/audio_video_recorder.cpp)
+target_link_libraries(audio_video_recorder ${catkin_LIBRARIES} ${GST1.0_LIBRARIES} ${Boost_LIBRARIES})
+add_dependencies(audio_video_recorder ${catkin_EXPORTED_TARGETS})
+
+install(TARGETS audio_video_recorder
+   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+install(DIRECTORY launch sample
+   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/audio_video_recorder/README.md
+++ b/audio_video_recorder/README.md
@@ -1,0 +1,78 @@
+# audio_video_recorder
+
+ROS package for recording audio and video synchronously
+
+![[Full video on Google Drive](https://drive.google.com/file/d/1TWnRKbOdq6jPza82eNhhjn56lQXRxWjl/view?usp=sharing)
+](.media/pr2_sample.gif)
+
+[Full video on Google Drive](https://drive.google.com/file/d/1TWnRKbOdq6jPza82eNhhjn56lQXRxWjl/view?usp=sharing)
+
+## Sample
+
+You can record audio and video on your laptop.
+
+```bash
+roslaunch audio_video_recorder sample_audio_video_recorder.launch
+```
+
+## Parameters
+
+Node: `audio_video_recorder/audio_video_recorder`
+
+### Common parameters
+
+- `queue_size` (`Int`, default: `100`)
+
+  Queue size
+
+- `do_timestamp` (`Bool`, default: `true`)
+
+  Do timestamp or not (`false` is not working now.)
+
+- `file_location` (`String`, default: `/tmp/test.avi`)
+
+  Output file location
+
+- `file_format` (`String`, default: `avi`)
+
+  Output file format (Only `avi` is supported now.)
+
+### Audio parameters
+
+- `audio_format` (`String`, default: `mp3`)
+
+  Audio format
+
+- `audio_sample_format` (`String`, default: `S16LE`)
+
+  Audio sample format
+
+- `audio_channels` (`Int`, default: `1`)
+
+  Number of audio channel
+
+- `audio_depth` (`Int`, default: `16`)
+
+  Audio depth
+
+- `audio_sample_rate` (`Int`, default: `16000`)
+
+  Audio sample rate
+
+### Video parameters
+
+- `video_encoding` (`String`, default: `RGB`)
+
+  Video encoding for `gstreamer`
+
+- `video_height` (`Int`, default: `480`)
+
+  Video image height
+
+- `video_width` (`Int`, default: `640`)
+
+  Video image width
+
+- `video_framerate` (`Int`, default: `30`)
+
+  Video frame rate

--- a/audio_video_recorder/README.md
+++ b/audio_video_recorder/README.md
@@ -39,6 +39,8 @@ Node: `audio_video_recorder/audio_video_recorder`
 
 ### Audio parameters
 
+Parameters for subscribing audio topic
+
 - `audio_format` (`String`, default: `mp3`)
 
   Format of audio topic. `mp3` and `wave` are supported.
@@ -60,6 +62,8 @@ Node: `audio_video_recorder/audio_video_recorder`
   Sample rate of audio topic
 
 ### Video parameters
+
+Parameters for subscribing image topic
 
 - `video_encoding` (`String`, default: `RGB`)
 

--- a/audio_video_recorder/README.md
+++ b/audio_video_recorder/README.md
@@ -7,7 +7,7 @@ ROS package for recording audio and video synchronously
 
 [Full video on Google Drive](https://drive.google.com/file/d/1TWnRKbOdq6jPza82eNhhjn56lQXRxWjl/view?usp=sharing)
 
-## Sample
+## Sample launch
 
 You can record audio and video in one file (i.e. `AVI` file) on your computer.
 
@@ -15,15 +15,23 @@ You can record audio and video in one file (i.e. `AVI` file) on your computer.
 roslaunch audio_video_recorder sample_audio_video_recorder.launch
 ```
 
-## Parameters
+## Node: `audio_video_recorder`
 
-Node: `audio_video_recorder/audio_video_recorder`
+Node for recording audio and image topics into video file (i.e. `AVI` file)
 
-### Common parameters
+### Subscribing topics
 
-- `queue_size` (`Int`, default: `100`)
+- `~input/audio` (`audio_common_msgs/AudioData`)
 
-  Queue size
+  Audio topic name in `audio_common_msgs/AudioData` format
+
+- `~input/image` (`sensor_msgs/Image`)
+
+  Image topic name in `sensor_msgs/Image` format
+
+### Parameters
+
+#### Common parameters for recording
 
 - `file_name` (`String`, default: `/tmp/test.avi`)
 
@@ -33,9 +41,16 @@ Node: `audio_video_recorder/audio_video_recorder`
 
   Output file format (Only `avi` is supported now.)
 
-### Audio parameters
 
-Parameters for subscribing audio topic
+#### Common parameters for subscribing topic
+
+- `queue_size` (`Int`, default: `100`)
+
+  Queue size
+
+#### Parameters for subscribing audio topic `audio_common_msgs/AudioData`
+
+Audio topic should be `audio_common_msgs/AudioData` format.
 
 - `audio_format` (`String`, default: `mp3`)
 
@@ -57,9 +72,9 @@ Parameters for subscribing audio topic
 
   Sample rate of audio topic
 
-### Video parameters
+#### Parameters for subscribing image topic `sensor_msgs/Image`
 
-Parameters for subscribing image topic
+Image topic should be `sensor_msgs/Image` format
 
 - `video_encoding` (`String`, default: `RGB`)
 

--- a/audio_video_recorder/README.md
+++ b/audio_video_recorder/README.md
@@ -9,7 +9,7 @@ ROS package for recording audio and video synchronously
 
 ## Sample
 
-You can record audio and video on your laptop.
+You can record audio and video in one file (i.e. `AVI` file) on your computer.
 
 ```bash
 roslaunch audio_video_recorder sample_audio_video_recorder.launch
@@ -41,38 +41,38 @@ Node: `audio_video_recorder/audio_video_recorder`
 
 - `audio_format` (`String`, default: `mp3`)
 
-  Audio format
+  Format of audio topic. `mp3` and `wave` are supported.
 
 - `audio_sample_format` (`String`, default: `S16LE`)
 
-  Audio sample format
+  Sample format of audio topic.
 
 - `audio_channels` (`Int`, default: `1`)
 
-  Number of audio channel
+  Number of channel of audio topic.
 
 - `audio_depth` (`Int`, default: `16`)
 
-  Audio depth
+  Depth of audio topic
 
 - `audio_sample_rate` (`Int`, default: `16000`)
 
-  Audio sample rate
+  Sample rate of audio topic
 
 ### Video parameters
 
 - `video_encoding` (`String`, default: `RGB`)
 
-  Video encoding for `gstreamer`
+  Encoding of image topic. `RGB` and `BGR` is supported.
 
 - `video_height` (`Int`, default: `480`)
 
-  Video image height
+  Height of image topic.
 
 - `video_width` (`Int`, default: `640`)
 
-  Video image width
+  Width of image topic
 
 - `video_framerate` (`Int`, default: `30`)
 
-  Video frame rate
+  Frame rate of image topic

--- a/audio_video_recorder/README.md
+++ b/audio_video_recorder/README.md
@@ -25,10 +25,6 @@ Node: `audio_video_recorder/audio_video_recorder`
 
   Queue size
 
-- `do_timestamp` (`Bool`, default: `true`)
-
-  Do timestamp or not (`false` is not working now.)
-
 - `file_name` (`String`, default: `/tmp/test.avi`)
 
   Output file name

--- a/audio_video_recorder/README.md
+++ b/audio_video_recorder/README.md
@@ -9,10 +9,10 @@ ROS package for recording audio and video synchronously
 
 ## Sample launch
 
-You can record audio and video in one file (i.e. `AVI` file) on your computer.
+You can record usb camera and microphone output into one video file (i.e. `AVI` file) with the following command.
 
 ```bash
-roslaunch audio_video_recorder sample_audio_video_recorder.launch
+roslaunch audio_video_recorder sample_audio_video_recorder.launch file_name:=<output file path>
 ```
 
 ## Node: `audio_video_recorder`

--- a/audio_video_recorder/README.md
+++ b/audio_video_recorder/README.md
@@ -7,87 +7,68 @@ ROS package for recording audio and video synchronously
 
 [Full video on Google Drive](https://drive.google.com/file/d/1TWnRKbOdq6jPza82eNhhjn56lQXRxWjl/view?usp=sharing)
 
-## Sample launch
+## Sample
 
-You can record usb camera and microphone output into one video file (i.e. `AVI` file) with the following command.
+You can record audio and video on your laptop.
 
 ```bash
-roslaunch audio_video_recorder sample_audio_video_recorder.launch file_name:=<output file path>
+roslaunch audio_video_recorder sample_audio_video_recorder.launch
 ```
 
-## Node: `audio_video_recorder`
+## Parameters
 
-Node for recording audio and image topics into video file (i.e. `AVI` file)
+Node: `audio_video_recorder/audio_video_recorder`
 
-### Subscribing topics
-
-- `~input/audio` (`audio_common_msgs/AudioData`)
-
-  Audio topic name in `audio_common_msgs/AudioData` format
-
-- `~input/image` (`sensor_msgs/Image`)
-
-  Image topic name in `sensor_msgs/Image` format
-
-### Parameters
-
-#### Common parameters for recording
-
-- `file_name` (`String`, default: `/tmp/test.avi`)
-
-  Output file name
-
-- `file_format` (`String`, default: `avi`)
-
-  Output file format (Only `avi` is supported now.)
-
-
-#### Common parameters for subscribing topic
+### Common parameters
 
 - `queue_size` (`Int`, default: `100`)
 
   Queue size
 
-#### Parameters for subscribing audio topic `audio_common_msgs/AudioData`
+- `file_name` (`String`, default: `/tmp/test.avi`)
 
-Audio topic should be `audio_common_msgs/AudioData` format.
+  Output file location
+
+- `file_format` (`String`, default: `avi`)
+
+  Output file format (Only `avi` is supported now.)
+
+### Audio parameters
 
 - `audio_format` (`String`, default: `mp3`)
 
-  Format of audio topic. `mp3` and `wave` are supported.
+  Audio format
 
 - `audio_sample_format` (`String`, default: `S16LE`)
 
-  Sample format of audio topic.
+  Audio sample format
 
 - `audio_channels` (`Int`, default: `1`)
 
-  Number of channel of audio topic.
+  Number of audio channel
 
 - `audio_depth` (`Int`, default: `16`)
 
-  Depth of audio topic
+  Audio depth
 
 - `audio_sample_rate` (`Int`, default: `16000`)
 
-  Sample rate of audio topic
+  Audio sample rate
 
-#### Parameters for subscribing image topic `sensor_msgs/Image`
-
-Image topic should be `sensor_msgs/Image` format
+### Video parameters
 
 - `video_encoding` (`String`, default: `RGB`)
 
-  Encoding of image topic. `RGB` and `BGR` is supported.
+  Video encoding for `gstreamer`
 
 - `video_height` (`Int`, default: `480`)
 
-  Height of image topic.
+  Video image height
 
 - `video_width` (`Int`, default: `640`)
 
-  Width of image topic
+  Video image width
 
 - `video_framerate` (`Int`, default: `30`)
 
-  Frame rate of image topic
+  Video frame rate

--- a/audio_video_recorder/README.md
+++ b/audio_video_recorder/README.md
@@ -29,9 +29,9 @@ Node: `audio_video_recorder/audio_video_recorder`
 
   Do timestamp or not (`false` is not working now.)
 
-- `file_location` (`String`, default: `/tmp/test.avi`)
+- `file_name` (`String`, default: `/tmp/test.avi`)
 
-  Output file location
+  Output file name
 
 - `file_format` (`String`, default: `avi`)
 

--- a/audio_video_recorder/include/audio_video_recorder/audio_video_recorder.h
+++ b/audio_video_recorder/include/audio_video_recorder/audio_video_recorder.h
@@ -1,0 +1,43 @@
+#include <boost/thread.hpp>
+#include <gst/gst.h>
+#include <gst/app/gstappsrc.h>
+#include <ros/ros.h>
+#include <message_filters/subscriber.h>
+#include <message_filters/time_synchronizer.h>
+#include <message_filters/sync_policies/approximate_time.h>
+#include <message_filters/synchronizer.h>
+
+#include "audio_common_msgs/AudioData.h"
+#include "sensor_msgs/Image.h"
+
+namespace audio_video_recorder
+{
+  class AudioVideoRecorder
+  {
+    public:
+      AudioVideoRecorder() {}
+
+      typedef message_filters::sync_policies::ExactTime<sensor_msgs::Image, audio_common_msgs::AudioData> ExactSyncPolicy;
+      typedef message_filters::sync_policies::ApproximateTime<sensor_msgs::Image, audio_common_msgs::AudioData> ApproximateSyncPolicy;
+
+      void initialize();
+      void callbackImage(const sensor_msgs::ImageConstPtr &image_msg);
+      void callbackAudio(const audio_common_msgs::AudioDataConstPtr &audio_msg);
+      static void callbackPad(GstElement *decodebin, GstPad *pad, gpointer data);
+    protected:
+      boost::shared_ptr<ros::NodeHandle> _nh;
+      ros::Subscriber _sub_image, _sub_audio;
+      boost::shared_ptr<message_filters::Synchronizer<ExactSyncPolicy> > _sync;
+      boost::shared_ptr<message_filters::Synchronizer<ApproximateSyncPolicy> > _async;
+
+      boost::thread _gst_thread;
+      GstElement *_pipeline, *_bin, *_mux, *_sink;
+      GstElement *_audio_source, *_audio_filter;
+      GstElement *_audio_source_queue, *_audio_queue;
+      GstElement *_audio_encoder, *_audio_decoder;
+      GstElement *_video_source, *_video_filter;
+      GstElement *_video_source_queue, *_video_queue;
+      GstElement *_video_convert;
+      GMainLoop *_loop;
+  };
+}

--- a/audio_video_recorder/launch/audio_video_recorder.launch
+++ b/audio_video_recorder/launch/audio_video_recorder.launch
@@ -1,0 +1,36 @@
+<launch>
+  <arg name="audio_topic_name" />
+  <arg name="image_topic_name" />
+  <arg name="queue_size" />
+  <arg name="do_timestamp" />
+  <arg name="file_location" />
+  <arg name="file_format" />
+  <arg name="audio_channels" />
+  <arg name="audio_sample_rate" />
+  <arg name="audio_format" />
+  <arg name="audio_sample_format" />
+  <arg name="video_height" />
+  <arg name="video_width" />
+  <arg name="video_framerate" />
+  <arg name="video_encoding" />
+
+  <node name="audio_video_recorder" pkg="audio_video_recorder"
+        type="audio_video_recorder" output="screen">
+    <remap from="~input/audio" to="$(arg audio_topic_name)" />
+    <remap from="~input/image" to="$(arg image_topic_name)" />
+    <rosparam subst_value="true">
+      queue_size: $(arg queue_size)
+      do_timestamp: $(arg do_timestamp)
+      file_location: $(arg file_location)
+      file_format: $(arg file_format)
+      audio_channels: $(arg audio_channels)
+      audio_sample_rate: $(arg audio_sample_rate)
+      audio_format: $(arg audio_format)
+      audio_sample_format: $(arg audio_sample_format)
+      video_height: $(arg video_height)
+      video_width: $(arg video_width)
+      video_framerate: $(arg video_framerate)
+      video_encoding: $(arg video_encoding)
+    </rosparam>
+  </node>
+</launch>

--- a/audio_video_recorder/launch/audio_video_recorder.launch
+++ b/audio_video_recorder/launch/audio_video_recorder.launch
@@ -2,7 +2,6 @@
   <arg name="audio_topic_name" />
   <arg name="image_topic_name" />
   <arg name="queue_size" />
-  <arg name="do_timestamp" />
   <arg name="file_name" />
   <arg name="file_format" />
   <arg name="audio_channels" />
@@ -20,7 +19,6 @@
     <remap from="~input/image" to="$(arg image_topic_name)" />
     <rosparam subst_value="true">
       queue_size: $(arg queue_size)
-      do_timestamp: $(arg do_timestamp)
       file_name: $(arg file_name)
       file_format: $(arg file_format)
       audio_channels: $(arg audio_channels)

--- a/audio_video_recorder/launch/audio_video_recorder.launch
+++ b/audio_video_recorder/launch/audio_video_recorder.launch
@@ -3,7 +3,7 @@
   <arg name="image_topic_name" />
   <arg name="queue_size" />
   <arg name="do_timestamp" />
-  <arg name="file_location" />
+  <arg name="file_name" />
   <arg name="file_format" />
   <arg name="audio_channels" />
   <arg name="audio_sample_rate" />
@@ -21,7 +21,7 @@
     <rosparam subst_value="true">
       queue_size: $(arg queue_size)
       do_timestamp: $(arg do_timestamp)
-      file_location: $(arg file_location)
+      file_name: $(arg file_name)
       file_format: $(arg file_format)
       audio_channels: $(arg audio_channels)
       audio_sample_rate: $(arg audio_sample_rate)

--- a/audio_video_recorder/package.xml
+++ b/audio_video_recorder/package.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>audio_video_recorder</name>
+  <version>2.2.11</version>
+  <description>ROS package for recording image and audio synchronously</description>
+
+  <author email="shingogo.5511@gmail.com">Shingo Kitagawa</author>
+  <maintainer email="shingogo.5511@gmail.com">Shingo Kitagawa</maintainer>
+
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>roscpp</build_depend>
+  <build_depend>audio_common_msgs</build_depend>
+  <build_depend>libgstreamer1.0-dev</build_depend>
+  <build_depend>libgstreamer-plugins-base1.0-dev</build_depend>
+  <build_depend>message_filters</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>audio_common_msgs</exec_depend>
+  <exec_depend>gstreamer1.0</exec_depend>
+  <exec_depend>gstreamer1.0-plugins-base</exec_depend>
+  <exec_depend>gstreamer1.0-plugins-good</exec_depend>
+  <exec_depend>gstreamer1.0-plugins-ugly</exec_depend>
+  <exec_depend>message_filters</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+</package>

--- a/audio_video_recorder/sample/pr2_audio_video_recorder.launch
+++ b/audio_video_recorder/sample/pr2_audio_video_recorder.launch
@@ -1,0 +1,31 @@
+<launch>
+  <arg name="queue_size" default="100" />
+  <arg name="do_timestamp" default="true" />
+  <arg name="file_location" default="/tmp/test.avi" />
+  <arg name="file_format" default="avi" />
+  <arg name="audio_channels" default="1" />
+  <arg name="audio_sample_rate" default="16000" />
+  <arg name="audio_format" default="wave" />
+  <arg name="audio_sample_format" default="S16LE" />
+  <arg name="video_height" default="480" />
+  <arg name="video_width" default="640" />
+  <arg name="video_framerate" default="30" />
+  <arg name="video_encoding" default="BGR" />
+
+  <include file="$(find audio_video_recorder)/launch/audio_video_recorder.launch">
+    <arg name="audio_topic_name" value="/audio" />
+    <arg name="image_topic_name" value="/kinect_head/rgb/image_rect_color" />
+    <arg name="queue_size" value="$(arg queue_size)" />
+    <arg name="do_timestamp" value="$(arg do_timestamp)" />
+    <arg name="file_location" value="$(arg file_location)" />
+    <arg name="file_format" value="$(arg file_format)" />
+    <arg name="audio_channels" value="$(arg audio_channels)" />
+    <arg name="audio_sample_rate" value="$(arg audio_sample_rate)" />
+    <arg name="audio_format" value="$(arg audio_format)" />
+    <arg name="audio_sample_format" value="$(arg audio_sample_format)" />
+    <arg name="video_height" value="$(arg video_height)" />
+    <arg name="video_width" value="$(arg video_width)" />
+    <arg name="video_framerate" value="$(arg video_framerate)" />
+    <arg name="video_encoding" value="$(arg video_encoding)" />
+  </include>
+</launch>

--- a/audio_video_recorder/sample/pr2_audio_video_recorder.launch
+++ b/audio_video_recorder/sample/pr2_audio_video_recorder.launch
@@ -1,6 +1,5 @@
 <launch>
   <arg name="queue_size" default="100" />
-  <arg name="do_timestamp" default="true" />
   <arg name="file_name" default="/tmp/test.avi" />
   <arg name="file_format" default="avi" />
   <arg name="audio_channels" default="1" />
@@ -16,7 +15,6 @@
     <arg name="audio_topic_name" value="/audio" />
     <arg name="image_topic_name" value="/kinect_head/rgb/image_rect_color" />
     <arg name="queue_size" value="$(arg queue_size)" />
-    <arg name="do_timestamp" value="$(arg do_timestamp)" />
     <arg name="file_name" value="$(arg file_name)" />
     <arg name="file_format" value="$(arg file_format)" />
     <arg name="audio_channels" value="$(arg audio_channels)" />

--- a/audio_video_recorder/sample/pr2_audio_video_recorder.launch
+++ b/audio_video_recorder/sample/pr2_audio_video_recorder.launch
@@ -1,7 +1,7 @@
 <launch>
   <arg name="queue_size" default="100" />
   <arg name="do_timestamp" default="true" />
-  <arg name="file_location" default="/tmp/test.avi" />
+  <arg name="file_name" default="/tmp/test.avi" />
   <arg name="file_format" default="avi" />
   <arg name="audio_channels" default="1" />
   <arg name="audio_sample_rate" default="16000" />
@@ -17,7 +17,7 @@
     <arg name="image_topic_name" value="/kinect_head/rgb/image_rect_color" />
     <arg name="queue_size" value="$(arg queue_size)" />
     <arg name="do_timestamp" value="$(arg do_timestamp)" />
-    <arg name="file_location" value="$(arg file_location)" />
+    <arg name="file_name" value="$(arg file_name)" />
     <arg name="file_format" value="$(arg file_format)" />
     <arg name="audio_channels" value="$(arg audio_channels)" />
     <arg name="audio_sample_rate" value="$(arg audio_sample_rate)" />

--- a/audio_video_recorder/sample/sample_audio_video_recorder.launch
+++ b/audio_video_recorder/sample/sample_audio_video_recorder.launch
@@ -1,0 +1,46 @@
+<launch>
+  <arg name="queue_size" default="100" />
+  <arg name="do_timestamp" default="true" />
+  <arg name="file_location" default="/tmp/test.avi" />
+  <arg name="file_format" default="avi" />
+  <arg name="audio_channels" default="1" />
+  <arg name="audio_sample_rate" default="44100" />
+  <arg name="audio_format" default="mp3" />
+  <arg name="audio_sample_format" default="S16LE" />
+  <arg name="video_height" default="480" />
+  <arg name="video_width" default="640" />
+  <arg name="video_framerate" default="30" />
+  <arg name="video_encoding" default="RGB" />
+
+  <node name="usb_cam_node" pkg="usb_cam" type="usb_cam_node">
+    <rosparam subst_value="true">
+      image_height: $(arg video_height)
+      image_width: $(arg video_width)
+      framerate: $(arg video_framerate)
+    </rosparam>
+  </node>
+
+  <include file="$(find audio_capture)/launch/capture.launch">
+    <arg name="format" value="$(arg audio_format)" />
+    <arg name="channels" value="$(arg audio_channels)" />
+    <arg name="sample_rate" value="$(arg audio_sample_rate)" />
+    <arg name="sample_format" value="$(arg audio_sample_format)" />
+  </include>
+
+  <include file="$(find audio_video_recorder)/launch/audio_video_recorder.launch">
+    <arg name="audio_topic_name" value="/audio/audio" />
+    <arg name="image_topic_name" value="/usb_cam_node/image_raw" />
+    <arg name="queue_size" value="$(arg queue_size)" />
+    <arg name="do_timestamp" value="$(arg do_timestamp)" />
+    <arg name="file_location" value="$(arg file_location)" />
+    <arg name="file_format" value="$(arg file_format)" />
+    <arg name="audio_channels" value="$(arg audio_channels)" />
+    <arg name="audio_sample_rate" value="$(arg audio_sample_rate)" />
+    <arg name="audio_format" value="$(arg audio_format)" />
+    <arg name="audio_sample_format" value="$(arg audio_sample_format)" />
+    <arg name="video_height" value="$(arg video_height)" />
+    <arg name="video_width" value="$(arg video_width)" />
+    <arg name="video_framerate" value="$(arg video_framerate)" />
+    <arg name="video_encoding" value="$(arg video_encoding)" />
+  </include>
+</launch>

--- a/audio_video_recorder/sample/sample_audio_video_recorder.launch
+++ b/audio_video_recorder/sample/sample_audio_video_recorder.launch
@@ -1,6 +1,5 @@
 <launch>
   <arg name="queue_size" default="100" />
-  <arg name="do_timestamp" default="true" />
   <arg name="file_name" default="/tmp/test.avi" />
   <arg name="file_format" default="avi" />
   <arg name="audio_channels" default="1" />
@@ -31,7 +30,6 @@
     <arg name="audio_topic_name" value="/audio/audio" />
     <arg name="image_topic_name" value="/usb_cam_node/image_raw" />
     <arg name="queue_size" value="$(arg queue_size)" />
-    <arg name="do_timestamp" value="$(arg do_timestamp)" />
     <arg name="file_name" value="$(arg file_name)" />
     <arg name="file_format" value="$(arg file_format)" />
     <arg name="audio_channels" value="$(arg audio_channels)" />

--- a/audio_video_recorder/sample/sample_audio_video_recorder.launch
+++ b/audio_video_recorder/sample/sample_audio_video_recorder.launch
@@ -1,7 +1,7 @@
 <launch>
   <arg name="queue_size" default="100" />
   <arg name="do_timestamp" default="true" />
-  <arg name="file_location" default="/tmp/test.avi" />
+  <arg name="file_name" default="/tmp/test.avi" />
   <arg name="file_format" default="avi" />
   <arg name="audio_channels" default="1" />
   <arg name="audio_sample_rate" default="44100" />
@@ -32,7 +32,7 @@
     <arg name="image_topic_name" value="/usb_cam_node/image_raw" />
     <arg name="queue_size" value="$(arg queue_size)" />
     <arg name="do_timestamp" value="$(arg do_timestamp)" />
-    <arg name="file_location" value="$(arg file_location)" />
+    <arg name="file_name" value="$(arg file_name)" />
     <arg name="file_format" value="$(arg file_format)" />
     <arg name="audio_channels" value="$(arg audio_channels)" />
     <arg name="audio_sample_rate" value="$(arg audio_sample_rate)" />

--- a/audio_video_recorder/src/audio_video_recorder.cpp
+++ b/audio_video_recorder/src/audio_video_recorder.cpp
@@ -1,0 +1,297 @@
+// modified work from audio_play/src/audio_play.cpp
+
+#include "audio_video_recorder/audio_video_recorder.h"
+
+#include <boost/thread.hpp>
+#include <gst/gst.h>
+#include <gst/app/gstappsrc.h>
+#include <ros/ros.h>
+#include <message_filters/subscriber.h>
+#include <message_filters/time_synchronizer.h>
+#include <message_filters/synchronizer.h>
+
+#include "audio_common_msgs/AudioData.h"
+#include "sensor_msgs/Image.h"
+
+namespace audio_video_recorder
+{
+
+  void AudioVideoRecorder::initialize()
+  {
+    GstCaps *audio_caps;
+    GstPad *audio_src_pad;
+    GstPad *audio_mux_pad, *g_audio_mux_pad;
+    GstPad *audio_cb_pad;
+
+    GstCaps *video_caps;
+    GstPad *video_src_pad;
+    GstPad *video_mux_pad, *g_video_mux_pad;
+
+    int queue_size;
+    bool do_timestamp;
+    std::string file_location;
+    std::string file_format;
+
+    // audio
+    int audio_channels;
+    int audio_depth;
+    int audio_sample_rate;
+    std::string audio_format;
+    std::string audio_sample_format;
+
+    // video
+    int video_framerate;
+    int video_height;
+    int video_width;
+    std::string video_encoding;
+
+    // common parameters
+    ros::param::param<int>("~queue_size", queue_size, 100);
+    ros::param::param<bool>("~do_timestamp", do_timestamp, true);
+    ros::param::param<std::string>("~file_location", file_location, "/tmp/test.avi");
+    ros::param::param<std::string>("~file_format", file_format, "avi");
+
+    // audio parameters
+    ros::param::param<int>("~audio_channels", audio_channels, 1);
+    ros::param::param<int>("~audio_depth", audio_depth, 16);
+    ros::param::param<int>("~audio_sample_rate", audio_sample_rate, 16000);
+    ros::param::param<std::string>("~audio_format", audio_format, "mp3");
+    ros::param::param<std::string>("~audio_sample_format", audio_sample_format, "S16LE");
+
+    // video parametes
+    ros::param::param<int>("~video_framerate", video_framerate, 30);
+    ros::param::param<int>("~video_height", video_height, 480);
+    ros::param::param<int>("~video_width", video_width, 640);
+    ros::param::param<std::string>("~video_encoding", video_encoding, "RGB");
+
+    _nh.reset (new ros::NodeHandle ("~"));
+    _loop = g_main_loop_new(NULL, false);
+    _pipeline = gst_pipeline_new("app_pipeline");
+
+    // audio source
+    audio_caps = gst_caps_new_simple(
+        "audio/x-raw",
+        "format", G_TYPE_STRING, audio_sample_format.c_str(),
+        "rate", G_TYPE_INT, audio_sample_rate,
+        "channels", G_TYPE_INT, audio_channels,
+        "width",    G_TYPE_INT, audio_depth,
+        "depth",    G_TYPE_INT, audio_depth,
+        "signed",   G_TYPE_BOOLEAN, TRUE,
+        "layout", G_TYPE_STRING, "interleaved",
+        NULL);
+    // _audio_source = gst_element_factory_make("audiotestsrc", "audio_source");
+    _audio_source = gst_element_factory_make("appsrc", "audio_source");
+    g_object_set(G_OBJECT(_audio_source), "do-timestamp", (do_timestamp) ? TRUE : FALSE, NULL);
+    g_object_set(G_OBJECT(_audio_source), "format", GST_FORMAT_TIME, NULL);
+    g_object_set(G_OBJECT(_audio_source), "is-live", TRUE, NULL);
+    gst_bin_add(GST_BIN(_pipeline), _audio_source);
+
+    // audio source queue
+    _audio_source_queue = gst_element_factory_make("queue", "audio_source_queue");
+    gst_bin_add(GST_BIN(_pipeline), _audio_source_queue);
+
+    // audio queue
+    _audio_queue = gst_element_factory_make("queue", "audio_queue");
+    gst_bin_add(GST_BIN(_pipeline), _audio_queue);
+    audio_src_pad = gst_element_get_static_pad(_audio_queue, "src");
+
+    // video source
+    video_caps = gst_caps_new_simple(
+        "video/x-raw",
+        "format", G_TYPE_STRING, video_encoding.c_str(),
+        "width", G_TYPE_INT, video_width,
+        "height", G_TYPE_INT, video_height,
+        "framerate", GST_TYPE_FRACTION, video_framerate, 1,
+        NULL);
+    // _video_source = gst_element_factory_make("videotestsrc", "video_source");
+    _video_source = gst_element_factory_make("appsrc", "video_source");
+    g_object_set(G_OBJECT(_video_source), "caps", video_caps, NULL);
+    g_object_set(G_OBJECT(_video_source), "format", GST_FORMAT_TIME, NULL);
+    g_object_set(G_OBJECT(_video_source), "do-timestamp", (do_timestamp) ? TRUE : FALSE, NULL);
+    g_object_set(G_OBJECT(_video_source), "is-live", TRUE, NULL);
+    gst_bin_add(GST_BIN(_pipeline), _video_source);
+    gst_caps_unref(video_caps);
+
+    // video source queue
+    _video_source_queue = gst_element_factory_make("queue", "video_source_queue");
+    gst_bin_add(GST_BIN(_pipeline), _video_source_queue);
+
+    // video convert
+    _video_convert = gst_element_factory_make("videoconvert", "video_convert");
+    gst_bin_add(GST_BIN(_pipeline), _video_convert);
+
+    // video x264 encoding
+    _video_filter = gst_element_factory_make("x264enc", "video_filter");
+    g_object_set(G_OBJECT(_video_filter), "tune", 4, NULL);
+    gst_bin_add(GST_BIN(_pipeline), _video_filter);
+    // video_src_pad = gst_element_get_static_pad(_video_filter, "src");
+
+    // video queue
+    _video_queue = gst_element_factory_make("queue", "video_queue");
+    gst_bin_add(GST_BIN(_pipeline), _video_queue);
+    video_src_pad = gst_element_get_static_pad(_video_queue, "src");
+
+    // mux
+    if (file_format == "avi")
+    {
+      _mux = gst_element_factory_make("avimux", "mux");
+      audio_mux_pad = gst_element_get_request_pad(_mux, "audio_%u");
+      video_mux_pad = gst_element_get_request_pad(_mux, "video_%u");
+    }
+    else
+    {
+      ROS_ERROR("Unsupported file format: %s", file_format.c_str());
+    }
+
+    // sink
+    _sink = gst_element_factory_make("filesink", "sink");
+    g_object_set(G_OBJECT(_sink), "location", file_location.c_str(), NULL);
+
+    // bin
+    _bin = gst_bin_new("bin");
+    g_object_set(G_OBJECT(_bin), "message-forward", TRUE, NULL);
+    gst_bin_add_many(GST_BIN(_bin), _mux, _sink, NULL);
+    if (gst_element_link_many(_mux, _sink, NULL) != TRUE)
+    {
+      ROS_ERROR("failed to link gstreamer");
+      return;
+    }
+    g_audio_mux_pad = gst_ghost_pad_new("audio_sink", audio_mux_pad);
+    gst_element_add_pad(_bin, g_audio_mux_pad);
+    gst_object_unref(GST_OBJECT(audio_mux_pad));
+
+    g_video_mux_pad = gst_ghost_pad_new("video_sink", video_mux_pad);
+    gst_element_add_pad(_bin, g_video_mux_pad);
+    gst_object_unref(GST_OBJECT(video_mux_pad));
+
+    gst_element_sync_state_with_parent(_bin);
+    gst_bin_add(GST_BIN(_pipeline), _bin);
+
+    ROS_INFO("Saving file to %s", file_location.c_str());
+    if (audio_format == "mp3")
+    {
+      // audio decode
+      _audio_decoder = gst_element_factory_make("decodebin", "audio_decoder");
+      g_signal_connect(_audio_decoder, "pad-added", G_CALLBACK(AudioVideoRecorder::callbackPad), this);
+      gst_bin_add(GST_BIN(_pipeline), _audio_decoder);
+
+      // audio caps filter
+      _audio_filter = gst_element_factory_make("capsfilter", "audio_filter");
+      g_object_set(G_OBJECT(_audio_filter), "caps", audio_caps, NULL);
+      gst_bin_add(GST_BIN(_pipeline), _audio_filter);
+      // audio_src_pad = gst_element_get_static_pad(_audio_filter, "src");
+
+      if (gst_element_link_many(_video_source, _video_source_queue, _video_convert, _video_filter, _video_queue, NULL) != TRUE ||
+          gst_pad_link(video_src_pad, g_video_mux_pad) != GST_PAD_LINK_OK ||
+          gst_element_link_many(_audio_source, _audio_source_queue, _audio_decoder, NULL) != TRUE ||
+          gst_element_link_many(_audio_filter, _audio_queue, NULL) != TRUE ||
+          gst_pad_link(audio_src_pad, g_audio_mux_pad) != GST_PAD_LINK_OK)
+      {
+        ROS_ERROR("failed to link mp3");
+        ROS_ERROR("failed to link gstreamer");
+        return;
+      }
+      else
+      {
+        ROS_INFO("succeeded to link mp3");
+      }
+      gst_caps_unref(audio_caps);
+    }
+    else if (audio_format == "wave")
+    {
+      g_object_set(G_OBJECT(_audio_source), "caps", audio_caps, NULL);
+
+      // audio wave encoding
+      _audio_encoder = gst_element_factory_make("wavenc", "audio_encoder");
+      gst_bin_add(GST_BIN(_pipeline), _audio_encoder);
+      // audio wave parse
+      _audio_decoder = gst_element_factory_make("wavparse", "audio_parser");
+      gst_bin_add(GST_BIN(_pipeline), _audio_decoder);
+      // audio_src_pad = gst_element_get_static_pad(_audio_decoder, "src");
+
+      if (gst_element_link_many(_video_source, _video_source_queue, _video_convert, _video_filter, _video_queue, NULL) != TRUE ||
+          gst_pad_link(video_src_pad, g_video_mux_pad) != GST_PAD_LINK_OK ||
+          gst_element_link_many(_audio_source, _audio_source_queue, _audio_encoder, _audio_decoder, _audio_queue, NULL) != TRUE ||
+          gst_pad_link(audio_src_pad, g_audio_mux_pad) != GST_PAD_LINK_OK)
+      {
+        ROS_ERROR("failed to link wave");
+        ROS_ERROR("failed to link gstreamer");
+        return;
+      }
+      else
+      {
+        ROS_INFO("succeeded to link wave");
+      }
+      gst_caps_unref(audio_caps);
+    }
+    else
+    {
+      ROS_ERROR("Unsupported audio format: %s", audio_format.c_str());
+    }
+    gst_element_set_state(GST_ELEMENT(_pipeline), GST_STATE_PLAYING);
+    _gst_thread = boost::thread( boost::bind(g_main_loop_run, _loop));
+    _sub_image = _nh->subscribe("input/image", queue_size, &AudioVideoRecorder::callbackImage, this);
+    _sub_audio = _nh->subscribe("input/audio", queue_size, &AudioVideoRecorder::callbackAudio, this);
+  }
+
+  void AudioVideoRecorder::callbackImage(const sensor_msgs::ImageConstPtr &image_msg)
+  {
+    GstFlowReturn ret;
+    GstBuffer *image_buffer = gst_buffer_new_and_alloc(image_msg->data.size());
+    gst_buffer_fill(image_buffer, 0, &image_msg->data[0], image_msg->data.size());
+    g_signal_emit_by_name(_video_source, "push-buffer", image_buffer, &ret);
+    return;
+  }
+
+  void AudioVideoRecorder::callbackAudio(const audio_common_msgs::AudioDataConstPtr &audio_msg)
+  {
+    GstFlowReturn ret;
+    GstBuffer *audio_buffer = gst_buffer_new_and_alloc(audio_msg->data.size());
+    gst_buffer_fill(audio_buffer, 0, &audio_msg->data[0], audio_msg->data.size());
+    g_signal_emit_by_name(_audio_source, "push-buffer", audio_buffer, &ret);
+    return;
+  }
+
+  void AudioVideoRecorder::callbackPad(GstElement *decodebin, GstPad *pad, gpointer data)
+  {
+    AudioVideoRecorder *client = reinterpret_cast<AudioVideoRecorder*>(data);
+    GstCaps *caps;
+    GstStructure *str;
+    GstPad *audiopad;
+
+    /* only link once */
+    audiopad = gst_element_get_static_pad (client->_audio_filter, "sink");
+    if (GST_PAD_IS_LINKED (audiopad))
+    {
+      ROS_ERROR("failed to get audio pad sink");
+      g_object_unref (audiopad);
+      return;
+    }
+
+    /* check media type */
+    caps = gst_pad_query_caps (pad, NULL);
+    str = gst_caps_get_structure (caps, 0);
+    if (!g_strrstr (gst_structure_get_name (str), "audio")) {
+      ROS_ERROR("failed to get media type");
+      gst_caps_unref (caps);
+      gst_object_unref (audiopad);
+      return;
+    }
+
+    gst_caps_unref (caps);
+    gst_pad_link (pad, audiopad);
+    g_object_unref (audiopad);
+    return;
+  }
+}
+
+
+int main (int argc, char **argv)
+{
+  ros::init(argc, argv, "audio_video_recorder");
+  gst_init(&argc, &argv);
+
+  audio_video_recorder::AudioVideoRecorder client;
+  client.initialize();
+  ros::spin();
+}

--- a/audio_video_recorder/src/audio_video_recorder.cpp
+++ b/audio_video_recorder/src/audio_video_recorder.cpp
@@ -28,7 +28,6 @@ namespace audio_video_recorder
     GstPad *video_mux_pad, *g_video_mux_pad;
 
     int queue_size;
-    // do_timestamp = true only works
     bool do_timestamp = true;
     std::string file_name;
     std::string file_format;

--- a/audio_video_recorder/src/audio_video_recorder.cpp
+++ b/audio_video_recorder/src/audio_video_recorder.cpp
@@ -29,7 +29,7 @@ namespace audio_video_recorder
 
     int queue_size;
     bool do_timestamp;
-    std::string file_location;
+    std::string file_name;
     std::string file_format;
 
     // audio
@@ -48,7 +48,7 @@ namespace audio_video_recorder
     // common parameters
     ros::param::param<int>("~queue_size", queue_size, 100);
     ros::param::param<bool>("~do_timestamp", do_timestamp, true);
-    ros::param::param<std::string>("~file_location", file_location, "/tmp/test.avi");
+    ros::param::param<std::string>("~file_name", file_name, "/tmp/test.avi");
     ros::param::param<std::string>("~file_format", file_format, "avi");
 
     // audio parameters
@@ -145,7 +145,7 @@ namespace audio_video_recorder
 
     // sink
     _sink = gst_element_factory_make("filesink", "sink");
-    g_object_set(G_OBJECT(_sink), "location", file_location.c_str(), NULL);
+    g_object_set(G_OBJECT(_sink), "location", file_name.c_str(), NULL);
 
     // bin
     _bin = gst_bin_new("bin");
@@ -167,7 +167,7 @@ namespace audio_video_recorder
     gst_element_sync_state_with_parent(_bin);
     gst_bin_add(GST_BIN(_pipeline), _bin);
 
-    ROS_INFO("Saving file to %s", file_location.c_str());
+    ROS_INFO("Saving file to %s", file_name.c_str());
     if (audio_format == "mp3")
     {
       // audio decode

--- a/audio_video_recorder/src/audio_video_recorder.cpp
+++ b/audio_video_recorder/src/audio_video_recorder.cpp
@@ -28,7 +28,8 @@ namespace audio_video_recorder
     GstPad *video_mux_pad, *g_video_mux_pad;
 
     int queue_size;
-    bool do_timestamp;
+    // do_timestamp = true only works
+    bool do_timestamp = true;
     std::string file_name;
     std::string file_format;
 
@@ -47,7 +48,6 @@ namespace audio_video_recorder
 
     // common parameters
     ros::param::param<int>("~queue_size", queue_size, 100);
-    ros::param::param<bool>("~do_timestamp", do_timestamp, true);
     ros::param::param<std::string>("~file_name", file_name, "/tmp/test.avi");
     ros::param::param<std::string>("~file_format", file_format, "avi");
 

--- a/jsk_common/package.xml
+++ b/jsk_common/package.xml
@@ -16,6 +16,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <exec_depend>audio_video_recorder</exec_depend>
   <exec_depend>dynamic_tf_publisher</exec_depend>
   <exec_depend>image_view2</exec_depend>
   <exec_depend>jsk_topic_tools</exec_depend>


### PR DESCRIPTION
add `audio_video_recorder` package in `jsk_common`
orginally developed in https://github.com/knorth55/audio_video_recorder

[//]: ![](https://github.com/knorth55/jsk_common/raw/audio-video-recorder/audio_video_recorder/.media/pr2_sample.gif)


https://user-images.githubusercontent.com/9300063/113512847-8e9f2600-95a1-11eb-8bed-17dcf9e08907.mp4


[Full video on Google Drive](https://drive.google.com/file/d/1TWnRKbOdq6jPza82eNhhjn56lQXRxWjl/view?usp=sharing)

cc. @nakaotatsuya 