### PR TITLE
Add latch mode to jsk_topic_tools/Relay

### DIFF
--- a/doc/jsk_topic_tools/lib/relay_nodelet.md
+++ b/doc/jsk_topic_tools/lib/relay_nodelet.md
@@ -1,0 +1,28 @@
+# Relay
+
+`jsk_topic_tools/Relay` is a node/nodelet that subscribes to `~input` topic and
+republishes all incoming data to `~output` topic like `topic_tools/Relay` but
+has several additional features such as latch and lazy mode.
+
+## Subscribing Topics
+
+* `~input` (`AnyMsg`)
+
+  Incoming topic to be relayed
+
+## Publishing Topics
+
+* `~output` (`AnyMsg`, same type as `~input`)
+
+  Outgoing topic to publish on
+
+## Parameters
+
+* `~always_subscribe` (`bool`, default: `false`)
+
+    If `true`, it turns off its lazy mode, where the input topic is subscribed
+    only when the output topic is subscribed.
+
+* `~latch` (`bool`, default: `false`)
+
+    If `true`, it publishes the output topic in latch mode.

--- a/jsk_topic_tools/include/jsk_topic_tools/relay_nodelet.h
+++ b/jsk_topic_tools/include/jsk_topic_tools/relay_nodelet.h
@@ -72,6 +72,8 @@ namespace jsk_topic_tools
     ConnectionStatus connection_status_;
     ros::NodeHandle pnh_;
     ros::ServiceServer change_output_topic_srv_;
+    bool always_subscribe_;
+    bool latch_;
     /** @brief
      * Pointer to TimeredDiagnosticUpdater to call
      * updateDiagnostic(diagnostic_updater::DiagnosticStatusWrapper&)


### PR DESCRIPTION
This allows us to make any topic latched. In my use case, I wanted to make `jsk_pcl/extract_indices/output` to be latched.