### PR TITLE
Set ccache prefix only for cmake <= 3.4

### DIFF
--- a/jsk_ros_patch/image_view2/CMakeLists.txt
+++ b/jsk_ros_patch/image_view2/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 2.8.3)
 project(image_view2)
 
 # Use ccache if installed to make it fast to generate object files
-find_program(CCACHE_FOUND ccache)
-if(CCACHE_FOUND)
-  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
-  set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
-endif(CCACHE_FOUND)
+if (CMAKE_VERSION VERSION_LESS 3.4)
+  find_program(CCACHE_FOUND ccache)
+  if(CCACHE_FOUND)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+  endif(CCACHE_FOUND)
+endif()
 
 if(NOT $ENV{ROS_DISTRO} STRLESS noetic)
   add_compile_options(-std=c++14)

--- a/jsk_topic_tools/CMakeLists.txt
+++ b/jsk_topic_tools/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 2.8.3)
 project(jsk_topic_tools)
 
 # Use ccache if installed to make it fast to generate object files
-find_program(CCACHE_FOUND ccache)
-if(CCACHE_FOUND)
-  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
-  set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
-endif(CCACHE_FOUND)
+if (CMAKE_VERSION VERSION_LESS 3.4)
+  find_program(CCACHE_FOUND ccache)
+  if(CCACHE_FOUND)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+  endif(CCACHE_FOUND)
+endif()
 
 find_package(catkin REQUIRED COMPONENTS
   dynamic_reconfigure


### PR DESCRIPTION
Same fix as https://github.com/jsk-ros-pkg/jsk_visualization/pull/780
This PR is fix for error about ccache like reported below:
https://github.com/CoatiSoftware/Sourcetrail/issues/1081