### PR TITLE
[WIP][tf_relay] add tf_relay package

### DIFF
--- a/jsk_coordination_system/tf_relay/CMakeLists.txt
+++ b/jsk_coordination_system/tf_relay/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(tf_relay)
+
+add_compile_options(-std=c++11)
+
+find_package(catkin REQUIRED COMPONENTS
+    roscpp
+    tf2
+    tf2_ros
+    geometry_msgs
+)
+
+find_package(Boost REQUIRED)
+
+catkin_package(
+  INCLUDE_DIRS include
+  LIBRARIES tf_relay
+  CATKIN_DEPENDS
+    roscpp
+    tf2
+    tf2_ros
+    geometry_msgs
+  DEPENDS
+    Boost
+)
+
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+)
+
+add_executable(tf_relay
+  src/tf_relay_node.cpp
+  src/tf_relay.cpp
+)
+target_link_libraries(tf_relay
+  ${catkin_LIBRARIES}
+  ${Boost_LIBRARIES}
+)

--- a/jsk_coordination_system/tf_relay/README.md
+++ b/jsk_coordination_system/tf_relay/README.md
@@ -1,0 +1,30 @@
+# tf_relay
+
+This node broadcasts transforms from a given fixed frame to a given output frame which is the same as reference frame in specified duraiton even when reference frame is not broadcasted.
+
+
+## Parameters
+
+- '~max_duration' ( double, default: 5.0 )
+
+cache duration for tf2 buffer.
+
+- '~timeout_duration' ( double, default: 0.05 )
+
+timeout duration for lookuptransform of tf.
+
+- '~timer_duration' ( double, default: 0.1 )
+
+spin duration for main process
+
+- '~reference_frame_id" ( string, default: 'reference_frame' )
+
+tf frame_id of reference frame.
+
+- '~output_frame_id' ( string, default: 'output_frame' )
+
+tf frame_id of output frame.
+
+- '~fixed_frame_id' ( string, default: 'fixed_frame' )
+
+tf frame_id of fixed frame.

--- a/jsk_coordination_system/tf_relay/include/tf_relay/tf_relay.h
+++ b/jsk_coordination_system/tf_relay/include/tf_relay/tf_relay.h
@@ -1,0 +1,66 @@
+#ifndef TF_RELAY_TF_RELAY_H__
+#define TF_RELAY_TF_RELAY_H__
+
+// Standaerd C++ Library
+#include <iostream>
+// ROS
+#include <ros/ros.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/transform_listener.h>
+// ROS message
+#include <geometry_msgs/TransformStamped.h>
+// Boost
+#include <boost/bind.hpp>
+
+namespace tf_relay {
+
+    /**
+     * @brief The TFRelay class is for calculate and publish walking status of each foot
+     */
+    class TFRelay
+    {
+        public:
+
+            TFRelay( ros::NodeHandle &nh,
+                     ros::NodeHandle &nh_private,
+                     tf2_ros::Buffer &tf_buffer,
+                     tf2_ros::TransformBroadcaster &tf_broadcaster );
+
+            /**
+             * @brief Main loop function. It will start spinner threads for subscribers and start main loop
+             * for calculation of commands to vibrators.
+             * @param nh ros::NodeHandle ros node handler
+             * @param nh_private ros::NodeHandle ros node handler with private namespace
+             * @param tf_buffer tf2_ros::Buffer tf2_ros buffer
+             */
+            void spin();
+
+        private:
+
+            /**
+             * ROS
+             */
+            ros::NodeHandle& nh_;
+            ros::NodeHandle& nh_private_;
+            tf2_ros::Buffer& tf_buffer_;
+            tf2_ros::TransformBroadcaster& tf_broadcaster_;
+            std::string reference_frame_id_;
+            std::string output_frame_id_;
+            std::string fixed_frame_id_;
+            ros::Duration duration_timeout_;
+            bool identity_initialize_;
+
+            bool initialized_;
+
+            geometry_msgs::TransformStamped msg_transform_;
+
+            /**
+             *
+             */
+            void callbackTimerTF( const ros::TimerEvent& );
+    };
+
+}
+
+#endif

--- a/jsk_coordination_system/tf_relay/package.xml
+++ b/jsk_coordination_system/tf_relay/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>tf_relay</name>
+  <version>2.2.11</version>
+  <description>The tf_relay package</description>
+
+  <maintainer email="k-okada@jsk.t.u-tokyo.ac.jp">Kei Okada</maintainer>
+  <author email="shinjo@jsk.imi.i.u-tokyo.ac.jp">Koki Shinjo</author>
+
+  <license>BSD</license>
+
+  <build_depend>boost</build_depend>
+  <depend>roscpp</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
+  <depend>geometry_msgs</depend>
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <export>
+  </export>
+</package>

--- a/jsk_coordination_system/tf_relay/src/tf_relay.cpp
+++ b/jsk_coordination_system/tf_relay/src/tf_relay.cpp
@@ -1,0 +1,112 @@
+// Standaerd C++ Library
+#include <iostream>
+// ROS
+#include <ros/ros.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/transform_listener.h>
+// ROS message
+#include <geometry_msgs/TransformStamped.h>
+// Boost
+#include <boost/bind.hpp>
+// USER
+#include "tf_relay/tf_relay.h"
+
+namespace tf_relay {
+
+    TFRelay::TFRelay( ros::NodeHandle &nh,
+                      ros::NodeHandle &nh_private,
+                      tf2_ros::Buffer &tf_buffer,
+                      tf2_ros::TransformBroadcaster &tf_broadcaster )
+        : nh_(nh), nh_private_(nh_private), tf_buffer_(tf_buffer), tf_broadcaster_(tf_broadcaster)
+    {
+        this->reference_frame_id_ = "reference_frame";
+        if ( nh_private.hasParam("reference_frame_id") ) {
+            nh_private.getParam("reference_frame_id", this->reference_frame_id_);
+        }
+
+        this->output_frame_id_ = "output_frame";
+        if ( nh_private.hasParam("output_frame_id") ) {
+            nh_private.getParam("output_frame_id", this->output_frame_id_);
+        }
+
+        this->fixed_frame_id_ = "fixed_frame";
+        if ( nh_private.hasParam("fixed_frame_id") ) {
+            nh_private.getParam("fixed_frame_id", this->fixed_frame_id_);
+        }
+
+        double timeout = 0.05;
+        if ( this->nh_private_.hasParam("timeout_duration") ) {
+            this->nh_private_.getParam("timeout_duration", timeout);
+        }
+        this->duration_timeout_ = ros::Duration(timeout);
+
+        this->identity_initialize_ = false;
+        if ( this->nh_private_.hasParam("identity_initialize") ) {
+            this->nh_private_.getParam("identity_initialize", this->identity_initialize_);
+        }
+
+        /**
+         *
+         */
+        this->initialized_ = false;
+
+        ROS_INFO("Initialization finished.");
+    }
+
+    void TFRelay::spin()
+    {
+        double timer_duration = 0.1;
+        if ( this->nh_private_.hasParam("timer_duration") ) {
+            this->nh_private_.getParam("timer_duration", timer_duration);
+        }
+
+        // start broadcaster timer
+        ros::Timer timer_tf = this->nh_.createTimer<TFRelay>( 
+                                ros::Duration(timer_duration),
+                                &TFRelay::callbackTimerTF,
+                                this
+                            );
+
+        //
+        ros::spin();
+    }
+
+    void TFRelay::callbackTimerTF( const ros::TimerEvent& )
+    {
+        try {
+            geometry_msgs::TransformStamped temp_transform =
+                this->tf_buffer_.lookupTransform(
+                        this->fixed_frame_id_,
+                        this->reference_frame_id_,
+                        ros::Time(0),
+                        this->duration_timeout_
+                        );
+            this->msg_transform_ = temp_transform;
+            this->msg_transform_.child_frame_id = this->output_frame_id_;
+            if ( not this->initialized_ ) {
+                this->initialized_ = true;
+            }
+        } catch (tf2::TransformException &ex) {
+            ROS_DEBUG("%s",ex.what());
+            if ( this->identity_initialize_ ) {
+                this->msg_transform_.header.frame_id = this->fixed_frame_id_;
+                this->msg_transform_.child_frame_id = this->output_frame_id_;
+                this->msg_transform_.transform.translation.x = 0.0;
+                this->msg_transform_.transform.translation.y = 0.0;
+                this->msg_transform_.transform.translation.z = 0.0;
+                this->msg_transform_.transform.rotation.x = 0.0;
+                this->msg_transform_.transform.rotation.y = 0.0;
+                this->msg_transform_.transform.rotation.z = 0.0;
+                this->msg_transform_.transform.rotation.w = 1.0;
+                this->initialized_ = true;
+            }
+        }
+        if ( this->initialized_ ) {
+            this->msg_transform_.header.stamp = ros::Time::now();
+            this->tf_broadcaster_.sendTransform(this->msg_transform_);
+        }
+        ROS_INFO("callback called.");
+    }
+
+}

--- a/jsk_coordination_system/tf_relay/src/tf_relay_node.cpp
+++ b/jsk_coordination_system/tf_relay/src/tf_relay_node.cpp
@@ -1,0 +1,29 @@
+// ROS
+#include <ros/ros.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/transform_listener.h>
+// USER
+#include "tf_relay/tf_relay.h"
+
+int main( int argc, char** argv )
+{
+    //
+    ros::init( argc, argv, "tf_relay_node" );
+    ros::NodeHandle nh;
+    ros::NodeHandle nh_private("~");
+
+    //
+    double max_duration;
+    nh_private.param<double>("max_duration", max_duration, 5.0);
+
+    //
+    ros::Duration tfduration(max_duration);
+    tf2_ros::Buffer            tf_buffer(tfduration);
+    tf2_ros::TransformListener tf_listener(tf_buffer);
+    tf2_ros::TransformBroadcaster tf_broadcaster;
+
+    //
+    tf_relay::TFRelay relay( nh, nh_private, tf_buffer, tf_broadcaster );
+    relay.spin();
+}


### PR DESCRIPTION
Add tf_relay package.

This node broadcasts transforms from a given fixed frame to a given output frame which is the same as reference frame in specified duraiton even when reference frame is not broadcasted.

this is usefull if you want to use AR marker frame even when robot cannot see it.

## TODO List

- [ ] Add demo launch
- [ ] Add tests