### PR TITLE
[jsk_data] add wait_timer for timer method

### DIFF
--- a/jsk_data/node_scripts/data_collection_server.py
+++ b/jsk_data/node_scripts/data_collection_server.py
@@ -285,10 +285,10 @@ class DataCollectionServer(object):
 
     def wait_msgs_update(self):
         now = rospy.Time.now()
-        for msg_key in self.msgs.keys():
+        for msg_key in self.msg.keys():
             time_diff = None
             while time_diff is None or time_diff < 0:
-                stamp = self.msgs[msg_key]['stamp']
+                stamp = self.msg[msg_key]['stamp']
                 time_diff = (stamp - now).to_sec()
                 rospy.logwarn_throttle(
                     1.0, "msgs is not updated after service request")

--- a/jsk_data/node_scripts/data_collection_server.py
+++ b/jsk_data/node_scripts/data_collection_server.py
@@ -177,6 +177,8 @@ class DataCollectionServer(object):
             }
 
     def sync_sub_and_save_cb(self, *msgs):
+        if self.wait_save_request:
+            self.wait_service_timestamp()
         self.sync_sub_cb(*msgs)
         self._sync_save()
 
@@ -310,10 +312,14 @@ class DataCollectionServer(object):
             return TriggerResponse(success=False, message=msg)
 
     def timer_cb(self, event):
+        if self.wait_save_request:
+            self.wait_service_timestamp()
         if self.start:
             result, msg = self._save()
 
     def sync_timer_cb(self, event):
+        if self.wait_save_request:
+            self.wait_service_timestamp()
         if self.start:
             result, msg = self._sync_save()
 


### PR DESCRIPTION
As to data_collection_server, wait_service_request for request method was implemented by https://github.com/jsk-ros-pkg/jsk_common/pull/1669 . 
So I apply it to the other methods such as timer method and all method.