### PR TITLE
use https:// instead of git://

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule ".travis"]
 	path = .travis
-	url = git://github.com/jsk-ros-pkg/jsk_travis
+	url = https://github.com/jsk-ros-pkg/jsk_travis


### PR DESCRIPTION
solve 'The unauthenticated git protocol on port 9418 is no longer supported.' error

```
Submodule '.travis' (git://github.com/jsk-ros-pkg/jsk_travis) registered for path '.travis'
Cloning into '/__w/jsk_common/jsk_common/.travis'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
fatal: clone of 'git://github.com/jsk-ros-pkg/jsk_travis' into submodule path '/__w/jsk_common/jsk_common/.travis' failed
Failed to clone '.travis'. Retry scheduled
Cloning into '/__w/jsk_common/jsk_common/.travis'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
fatal: clone of 'git://github.com/jsk-ros-pkg/jsk_travis' into submodule path '/__w/jsk_common/jsk_common/.travis' failed
Failed to clone '.travis' a second time, aborting
Error: Process completed with exit code 1.
```


https://github.com/jsk-ros-pkg/jsk_common/runs/5748261176?check_suite_focus=true