### PR TITLE
[jsk_tools] use python3-progressbar and python3-rosdep for noetic

### DIFF
--- a/jsk_tools/package.xml
+++ b/jsk_tools/package.xml
@@ -23,8 +23,10 @@
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-colorama</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-github</exec_depend> <!-- python-pygithub3 (pip pygithub3) requres python3-github -->
   <exec_depend>python-pygithub3</exec_depend>
-  <exec_depend>python-progressbar</exec_depend>
-  <exec_depend>python-rosdep</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-progressbar</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-progressbar</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-rosdep</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rosdep</exec_depend>
   <exec_depend>python-slacker-cli</exec_depend>
   <exec_depend>python-tabulate-pip</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-tabulate</exec_depend> <!-- python-tabulate enable since xenial (16.04) kinetic -->


### PR DESCRIPTION
add `python3-progressbar` and `python3-rosdep` for noetic

https://build.ros.org/job/Ndev__jsk_common__ubuntu_focal_amd64/29/console