### PR TITLE
[jsk_data] Strip newline at test code.

### DIFF
--- a/jsk_data/node_scripts/data_collection_server.py
+++ b/jsk_data/node_scripts/data_collection_server.py
@@ -169,6 +169,8 @@ class DataCollectionServer(object):
 
     def reconfig_cb(self, config, level):
         self.save_dir = osp.expanduser(config['save_dir'])
+        # remove newline and whitespace.
+        self.save_dir = self.save_dir.rstrip()
         if not osp.exists(self.save_dir):
             os.makedirs(self.save_dir)
         return config

--- a/jsk_data/tests/test_data_collection_server.py
+++ b/jsk_data/tests/test_data_collection_server.py
@@ -64,6 +64,7 @@ class TestDataCollectionServer(unittest.TestCase):
         self.assertTrue(ret.success)
 
         save_dir = rospy.get_param('/save_dir_request')
+        save_dir = save_dir.rstrip()
         save_dir = osp.expanduser(save_dir)
         self.check(save_dir, target='string')
 
@@ -78,6 +79,7 @@ class TestDataCollectionServer(unittest.TestCase):
         self.assertTrue(ret.success)
 
         save_dir = rospy.get_param('/save_dir_timer')
+        save_dir = save_dir.rstrip()
         save_dir = osp.expanduser(save_dir)
         self.check(save_dir, target='string')
 
@@ -86,6 +88,7 @@ class TestDataCollectionServer(unittest.TestCase):
         rospy.sleep(2)
 
         save_dir = rospy.get_param('/save_dir_all')
+        save_dir = save_dir.rstrip()
         save_dir = osp.expanduser(save_dir)
         self.check(save_dir, target='image')
 


### PR DESCRIPTION
# What is this?

Now 20.04 travis fails. 
https://github.com/jsk-ros-pkg/jsk_common/runs/6300763557?check_suite_focus=true#step:7:9754
This is because the result of the `mktemp -d` command** contains newline.
https://github.com/jsk-ros-pkg/jsk_common/blob/master/jsk_data/tests/data_collection_server.test#L30
This PR fix the test.