### PR TITLE
Loose test failed

### DIFF
--- a/jsk_topic_tools/test/test_connection.py
+++ b/jsk_topic_tools/test/test_connection.py
@@ -37,6 +37,8 @@ class TestConnection(unittest.TestCase):
         topic_type = rospy.get_param('~input_topic_type')
         check_connected_topics = rospy.get_param('~check_connected_topics')
         wait_time = rospy.get_param('~wait_for_connection', 0)
+        wait_for_disconnection_time = rospy.get_param(
+            '~wait_for_disconnection', 0)
         msg_class = roslib.message.get_message_class(topic_type)
         # Subscribe topic and bond connection
         sub = rospy.Subscriber('~input', msg_class,
@@ -59,7 +61,7 @@ class TestConnection(unittest.TestCase):
             sys.stderr.write('WARNING: running on rosdistro %s, and skipping '
                              'test for disconnection.\n' % ROS_DISTRO)
             return
-        rospy.sleep(1)  # wait for disconnection
+        rospy.sleep(wait_for_disconnection_time)  # wait for disconnection
         # Check specified topics do not exist
         _, subscriptions, _ = master.getSystemState()
         for check_topic in check_connected_topics:

--- a/jsk_topic_tools/test/test_connection_based_nodelet.test
+++ b/jsk_topic_tools/test/test_connection_based_nodelet.test
@@ -24,6 +24,7 @@
       input_topic_type: std_msgs/String
       check_connected_topics: [string_relay_1/output, string_relay_2/output, string_relay_3/output]
       wait_for_connection: 3
+      wait_for_disconnection: 10
     </rosparam>
     <remap from="~input" to="string_relay_4/output" />
   </test>

--- a/jsk_topic_tools/test/test_connection_based_transport.test
+++ b/jsk_topic_tools/test/test_connection_based_transport.test
@@ -11,6 +11,7 @@
       input_topic_type: sensor_msgs/Image
       check_connected_topics: [simple_image_transport/output, input_image]
       wait_for_connection: 10
+      wait_for_disconnection: 10
       hardware_id: /simple_image_transport
     </rosparam>
     <remap from="~input" to="simple_image_transport/output" />

--- a/jsk_topic_tools/test/test_stealth_relay.test
+++ b/jsk_topic_tools/test/test_stealth_relay.test
@@ -9,7 +9,8 @@
   </node>
   <test test-name="test_stealth_relay"
         pkg="jsk_topic_tools" type="test_stealth_relay.py"
-        time-limit="40" retry="3" />
+        time-limit="360" retry="10" />
+  <!-- stealth relay is prone to test failure under heavy load -->
 
   <node name="stealth_relay" pkg="jsk_topic_tools" type="stealth_relay"
         output="screen">

--- a/jsk_topic_tools/test/test_topic_buffer_fixed_rate.test
+++ b/jsk_topic_tools/test/test_topic_buffer_fixed_rate.test
@@ -19,7 +19,7 @@
   <param name="hztest_chatter_update/topic" value="chatter_update" />
   <param name="hztest_chatter_update/hz" value="0.1" />
   <param name="hztest_chatter_update/hzerror" value="2.5" />
-  <param name="hztest_chatter_update/test_duration" value="20.0" />
+  <param name="hztest_chatter_update/test_duration" value="30.0" />
   <test test-name="hztest_chatter_update"
         name="hztest_chatter_update"
         pkg="rostest" type="hztest"


### PR DESCRIPTION
# What is this?

Tests in `jsk_common` tends to fail.
https://github.com/jsk-ros-pkg/jsk_common/runs/6567117461?check_suite_focus=true
https://github.com/jsk-ros-pkg/jsk_common/runs/6549477630?check_suite_focus=true
https://github.com/jsk-ros-pkg/jsk_common/runs/6549477789?check_suite_focus=true
This is because programs that depend on the performance of the computer or sleep cannot pass the test in some cases.

This PR makes it easier to pass the test by making the following changes.

* [jsk_data/tes_data_collection_server] Check if text and yaml or text and image are saved in the subdirectory of `save_dir`.

* [jsk_topic_tools/test_stealth_relay] Fix test by waiting topic connection istead of rospy.sleep

* [jsk_topic_tools/test_stealth_relay] Increased stealth relay time and retry count

* [jsk_topic_tools/test_topic_buffer] Increased relay time and retry count

* [jsk_topic_tools/connection_based_nodelet] Add wait_for_disconnection param for conncection based nodelet test.

* [jsk_topic_tools/test_topic_buffer_update_rate] Extend duration time for chatter_update for low latency

