### PR TITLE
[jsk_topic_tools/diagnostics_nodelet] Poke when start subscribing.

### DIFF
--- a/jsk_topic_tools/include/jsk_topic_tools/diagnostic_nodelet.h
+++ b/jsk_topic_tools/include/jsk_topic_tools/diagnostic_nodelet.h
@@ -114,7 +114,11 @@ namespace jsk_topic_tools
      * True if summary is displayed as 'Warnings', otherwise it is displayed as 'Errors'
      */
     uint8_t diagnostic_error_level_;
-    
+
+    /** @brief
+     * Previous checked status of connection
+     */
+    ConnectionStatus previous_checked_connection_status_;
 
   private:
     

--- a/jsk_topic_tools/include/jsk_topic_tools/relay_nodelet.h
+++ b/jsk_topic_tools/include/jsk_topic_tools/relay_nodelet.h
@@ -81,6 +81,12 @@ namespace jsk_topic_tools
      */
     TimeredDiagnosticUpdater::Ptr diagnostic_updater_;
     VitalChecker::Ptr vital_checker_;
+
+    /** @brief
+     * Previous checked status of connection
+     */
+    ConnectionStatus previous_checked_connection_status_;
+
   };
 }
 

--- a/jsk_topic_tools/src/diagnostic_nodelet.cpp
+++ b/jsk_topic_tools/src/diagnostic_nodelet.cpp
@@ -46,6 +46,7 @@ namespace jsk_topic_tools
   void DiagnosticNodelet::onInit()
   {
     ConnectionBasedNodelet::onInit();
+    previous_checked_connection_status_ = NOT_SUBSCRIBED;
     diagnostic_updater_.reset(
       new TimeredDiagnosticUpdater(*pnh_, ros::Duration(1.0)));
     diagnostic_updater_->setHardwareID(getName());
@@ -79,6 +80,10 @@ namespace jsk_topic_tools
     diagnostic_updater::DiagnosticStatusWrapper &stat)
   {
     if (connection_status_ == SUBSCRIBED) {
+      if (previous_checked_connection_status_ != connection_status_) {
+        // Poke when start subscribing.
+        vital_checker_->poke();
+      }
       if (vital_checker_->isAlive()) {
         stat.summary(diagnostic_msgs::DiagnosticStatus::OK,
                      getName() + " running");
@@ -107,5 +112,6 @@ namespace jsk_topic_tools
                (boost::format("%d subscribers") %
                 publishers_[i].getNumSubscribers()).str());
     }
+    previous_checked_connection_status_ = connection_status_;
   }
 }

--- a/jsk_topic_tools/src/relay_nodelet.cpp
+++ b/jsk_topic_tools/src/relay_nodelet.cpp
@@ -77,6 +77,10 @@ namespace jsk_topic_tools
                    + pnh_.resolveName("input") + " active?");
     }
     else if (connection_status_ == SUBSCRIBED) {
+      if (previous_checked_connection_status_ != connection_status_) {
+        // Poke when start subscribing.
+        vital_checker_->poke();
+      }
       if (vital_checker_->isAlive()) {
         stat.summary(diagnostic_msgs::DiagnosticStatus::OK,
                      "subscribed: " + pnh_.resolveName("output"));
@@ -94,6 +98,7 @@ namespace jsk_topic_tools
     }
     stat.add("input topic", pnh_.resolveName("input"));
     stat.add("output topic", pnh_.resolveName("output"));
+    previous_checked_connection_status_ = connection_status_;
   }
   
   void Relay::inputCallback(const boost::shared_ptr<topic_tools::ShapeShifter const>& msg)


### PR DESCRIPTION
# What is this?

If the diagnostics nodelet is currently subscribed,but the publish function is not executed (`vital_checker->poke()` is not executed), it publishes diagnostics with an error level.
This publishes error level diagnostics only at the beginning because poke is not called when subscribing starts.

This is to change to output diagnostics at the OK level by inserting a poke when switching from the not subscribed state to the subscribed state.