### PR TITLE
[jsk_topic_tools/connection_based_transport] Update the time of last_published_time

### DIFF
--- a/doc/jsk_topic_tools/class/python_connection_based_transport.md
+++ b/doc/jsk_topic_tools/class/python_connection_based_transport.md
@@ -5,6 +5,18 @@
 This class is a base-class which can start subscribing topics if published topics are subscribed by the other node.
 This is abstruct class.
 
+Users inherit this class and define publisher by calling the `self.advertise` function.
+The return value of `self.advertise` is the `Publisher` class. User should execute publish in `callback` function.
+
+### For Expert
+
+When `publish` is executed, it is judged that this node is running normally, and published `diagnostics` becomes `OK` level.
+However, if the publisher is subscribed but the `publish` function is not called, the node is not working properly and `diagnostics` will be at the `ERROR` level.
+
+Some users may execute`publish` at any time (eg `rospy.Timer`).
+In that case, by executing the `self.poke` function in the callback function, the state of `diagnostics` will be `OK` level without executing publish.
+
+
 ## Parameter
 
 * `~always_subscribe` (Bool, default: `false`):

--- a/jsk_topic_tools/src/jsk_topic_tools/transport.py
+++ b/jsk_topic_tools/src/jsk_topic_tools/transport.py
@@ -141,18 +141,24 @@ class ConnectionBasedTransport(rospy.SubscribeListener):
     def is_subscribed(self):
         return self._connection_status == SUBSCRIBED
 
+    def poke(self):
+        """Update the time of last_published_time.
+
+        Update the time of last_published_time
+        to make it possible to take the difference time
+        between the time of start subscribing and the current time.
+        """
+        start_time = rospy.Time.now()
+        for pub in self._publishers:
+            pub.last_published_time = start_time
+
     def peer_subscribe(self, *args, **kwargs):
         rospy.logdebug('[{topic}] is subscribed'.format(topic=args[0]))
         if self._connection_status == NOT_SUBSCRIBED:
             self.subscribe()
             self._connection_status = SUBSCRIBED
 
-            # Update the time of last_published_time
-            # to make it possible to take the difference time
-            # between the time of start subscribing and the current time.
-            start_time = rospy.Time.now()
-            for pub in self._publishers:
-                pub.last_published_time = start_time
+            self.poke()
 
             if not self._ever_subscribed:
                 self._ever_subscribed = True

--- a/jsk_topic_tools/src/jsk_topic_tools/transport.py
+++ b/jsk_topic_tools/src/jsk_topic_tools/transport.py
@@ -146,6 +146,14 @@ class ConnectionBasedTransport(rospy.SubscribeListener):
         if self._connection_status == NOT_SUBSCRIBED:
             self.subscribe()
             self._connection_status = SUBSCRIBED
+
+            # Update the time of last_published_time
+            # to make it possible to take the difference time
+            # between the time of start subscribing and the current time.
+            start_time = rospy.Time.now()
+            for pub in self._publishers:
+                pub.last_published_time = start_time
+
             if not self._ever_subscribed:
                 self._ever_subscribed = True
 


### PR DESCRIPTION
# What is this?

Update the time of `last_published_time` to make it possible to take the difference time between the time of start subscribing and the current time.

`ConnectionBasedTransport` checks if topic is input and output normally.
https://github.com/jsk-ros-pkg/jsk_common/blob/df29bfbe32b07045be2a8f2a951a091a4f3c7d1e/jsk_topic_tools/src/jsk_topic_tools/transport.py#L176-L195

`self._connection_status` changes to `SUBSCRIBED` when node are subscribed.
The `is_running` function checks `last_published_time` and is `True` if it is published within the `1 / vital_rate` time.

If it hasn't been subscribed for a while now, `is_running` will always be `False` at first because `last_published_time` will not be updated all the time when it is not subscribed.

Related to https://github.com/jsk-ros-pkg/jsk_common/pull/1735 (c++'s diagnostics problem)

Also, I added the docs for `diagnostics function`.
```
Users inherit this class and define publisher by calling the `self.advertise` function.
The return value of `self.advertise` is the `Publisher` class. User should execute publish in `callback` function.

### For Expert

When `publish` is executed, it is judged that this node is running normally, and published `diagnostics` becomes `OK` level.
However, if the publisher is subscribed but the `publish` function is not called, the node is not working properly and `diagnostics` will be at the `ERROR` level.

Some users may execute`publish` at any time (eg `rospy.Timer`).
In that case, by executing the `self.poke` function in the callback function, the state of `diagnostics` will be `OK` level without executing publish.
```