### PR TITLE
[jsk_tools/test_topic_published.py] Add condition_%d option for checking topic value

### DIFF
--- a/doc/jsk_tools/test_nodes/test_topic_published.rst
+++ b/doc/jsk_tools/test_nodes/test_topic_published.rst
@@ -22,6 +22,22 @@ Parameters
 
   If it's ``True``, it tests if **not** published.
 
+- ``~condition_%d`` (``str``, Default: ``None``, Optional)
+
+  Check bool value condition using the given Python expression.
+  The Python expression can access any of the Python builtins plus:
+  ``topic`` (the topic of the message), ``m`` (the message) and ``t`` (time of message).
+
+  For example, topic is ``std_msgs/String`` and if you want to check whether a sentence is a ``hello``, you can do the following.
+
+  .. code-block:: bash
+    condition_0: m.data == 'hello'
+
+  If you want to check the frame id of the header, you can do the following.
+
+  .. code-block:: bash
+    condition_0: m.header.frame_id in ['base', 'base_link']
+
 
 Example
 -------

--- a/doc/jsk_tools/test_nodes/test_topic_published.rst
+++ b/doc/jsk_tools/test_nodes/test_topic_published.rst
@@ -38,6 +38,11 @@ Parameters
   .. code-block:: bash
     condition_0: m.header.frame_id in ['base', 'base_link']
 
+  Note that, use escape sequence when using the following symbols ``<(&lt;)``, ``>(&gt;)``, ``&(&amp;)``, ``'(&apos;)`` and ``"(&quot;)``.
+
+  .. code-block:: bash
+    condition_0: m.data &lt; 'spbm'
+
 
 Example
 -------

--- a/jsk_tools/src/test_topic_published.py
+++ b/jsk_tools/src/test_topic_published.py
@@ -155,7 +155,7 @@ class TestTopicPublished(unittest.TestCase):
                                 'But condition "{}" is not satified. '
                                 'Topic "{}"'.format(
                                     checker.topic_name, checker.condition,
-                                     checker.invalid_conditioned_msg))
+                                    checker.invalid_conditioned_msg))
                     sys.exit(1)
             try:
                 rospy.sleep(0.01)

--- a/jsk_tools/test/test_topic_published.launch
+++ b/jsk_tools/test/test_topic_published.launch
@@ -14,6 +14,7 @@
     </node>
   </group>
 
+  <!-- check without condition -->
   <test test-name="test_topic_published"
         name="test_topic_published"
         pkg="jsk_tools" type="test_topic_published.py">
@@ -25,14 +26,66 @@
     </rosparam>
   </test>
 
+  <!-- check with condition -->
+  <test test-name="test_topic_published_with_condition"
+        name="test_topic_published_with_condition"
+        pkg="jsk_tools" type="test_topic_published.py">
+    <rosparam>
+      topic_0: /string
+      timeout_0: 10
+      condition_0: "m.data == 'spam'"
+      check_after_kill_node: true
+      node_names: [publish_string,]
+    </rosparam>
+  </test>
+
+  <test test-name="test_topic_published_with_condition_negative"
+        name="test_topic_published_with_condition_negative"
+        pkg="jsk_tools" type="test_topic_published.py">
+    <rosparam>
+      topic_0: /string
+      timeout_0: 10
+      condition_0: "m.data == 'spamspam'"
+      negative_0: true
+      check_after_kill_node: true
+      node_names: [publish_string,]
+    </rosparam>
+  </test>
+
   <!-- test for namespace -->
   <group ns="ns" >
+    <!-- check without condition -->
     <test test-name="test_topic_published_for_namespace"
           name="test_topic_published"
           pkg="jsk_tools" type="test_topic_published.py">
       <rosparam>
         topic_0: string
         timeout_0: 10
+        check_after_kill_node: true
+        node_names: [publish_string,]
+      </rosparam>
+    </test>
+
+    <!-- check with condition -->
+    <test test-name="test_topic_published_for_namespace_with_condition"
+          name="test_topic_published_with_condition"
+          pkg="jsk_tools" type="test_topic_published.py">
+      <rosparam>
+        topic_0: string
+        timeout_0: 10
+        condition_0: "m.data == 'spam'"
+        check_after_kill_node: true
+        node_names: [publish_string,]
+      </rosparam>
+    </test>
+    <test test-name="test_topic_published_for_namespace_with_condition_negative"
+          name="test_topic_published_with_condition_negative"
+          pkg="jsk_tools" type="test_topic_published.py">
+      <rosparam>
+        topic_0: string
+        timeout_0: 10
+        condition_0: "m.data == 'spamspam'"
+        negative_0: true
         check_after_kill_node: true
         node_names: [publish_string,]
       </rosparam>

--- a/jsk_tools/test/test_topic_published.launch
+++ b/jsk_tools/test/test_topic_published.launch
@@ -33,7 +33,7 @@
     <rosparam>
       topic_0: /string
       timeout_0: 10
-      condition_0: "m.data == 'spam'"
+      condition_0: "m.data &lt; 'spbm'"
       check_after_kill_node: true
       node_names: [publish_string,]
     </rosparam>


### PR DESCRIPTION
# What is this?

Added condition option to check if the output topic value is correct.
The descriptions are followings.

```
- ``~condition_%d`` (``str``, Default: ``None``, Optional)

  Check bool value condition using the given Python expression.
  The Python expression can access any of the Python builtins plus:
  ``topic`` (the topic of the message), ``m`` (the message) and ``t`` (time of message).

  For example, topic is ``std_msgs/String`` and if you want to check whether a sentence is a ``hello``, you can do the following.

  .. code-block:: bash
    condition_0: m.data == 'hello'

  If you want to check the frame id of the header, you can do the following.

  .. code-block:: bash
    condition_0: m.header.frame_id in ['base', 'base_link']

  Note that, use escape sequence when using the following symbols ``<(&lt;)``, ``>(&gt;)``, ``&(&amp;)``, ``'(&apos;)`` and ``"(&quot;)``.

  .. code-block:: bash
    condition_0: m.data &lt; 'spbm'

```

https://github.com/jsk-ros-pkg/jsk_common/blob/cc9873caed9a27f2817e85000902c6244ea563a4/doc/jsk_tools/test_nodes/test_topic_published.rst