### PR TITLE
[jsk_tools] Seperate sanity check frequency and diagnostics publish frequency

### DIFF
--- a/doc/jsk_tools/scripts/sanity_diagnostics.md
+++ b/doc/jsk_tools/scripts/sanity_diagnostics.md
@@ -50,9 +50,13 @@ This node publishes essential robot topic and node status to `/diagnostics`.
       - /roswww
     ```
 
-* `~duration` (`Float`, default: `1`)
+* `~duration` (`Float`, default: `60`)
 
-    Duration in which sanity is checked and `/diagnostics` is published.
+    Duration in which sanity is checked.
+
+* `~pub_duration` (`Float`, default: `0.3`)
+
+    Duration in which `/diagnostics` is published.
 
 ## Usage
 

--- a/jsk_tools/sample/sample_sanity_diagnostics.launch
+++ b/jsk_tools/sample/sample_sanity_diagnostics.launch
@@ -24,7 +24,8 @@
   <node name="sanity_diagnostics" pkg="jsk_tools" type="sanity_diagnostics.py">
     <rosparam command="load" file="$(find jsk_tools)/sample/config/sanity_targets.yaml" />
     <rosparam subst_value="true">
-      duration: 1
+      duration: 10
+      pub_duration: 0.3
     </rosparam>
   </node>
 

--- a/jsk_tools/src/sanity_diagnostics.py
+++ b/jsk_tools/src/sanity_diagnostics.py
@@ -51,9 +51,9 @@ class SanityDiagnostics(object):
         self.last_time_check_node = rospy.Time.now()
         # Timer to call updater
         self.timer = rospy.Timer(
-            rospy.Duration(pub_duration), self.check_sanity)
+            rospy.Duration(pub_duration), self.pub_diagnostics)
 
-    def check_sanity(self, event):
+    def pub_diagnostics(self, event):
         self.updater.update()
 
     def check_topic(self, stat, topic_name):


### PR DESCRIPTION
### Problem

sanity diagnostics status in rqt_robot_monitor turns on and off.

### What I did

In this PR, I separate topic and node check frequency and diagnostics publish frequency.
- Check topic and node at low frequency to reduce CPU usage
- Publish diagnostics at high frequency to avoid the above problem.

Currently, when I run `roslaunch jsk_tools sample_sanity_diagnostics.launch`, `/diagnostics` topic is published at more than 1 Hz but `check_topic()` and `check_node()` methods are called at 0.1 Hz.