### PR TITLE
add extract_subtopic.py

### DIFF
--- a/doc/jsk_topic_tools/scripts/extract_subtopic.rst
+++ b/doc/jsk_topic_tools/scripts/extract_subtopic.rst
@@ -1,0 +1,22 @@
+static_transform_republisher.py
+===============================
+
+
+What is this?
+-------------
+
+This node can publish sub-field of input topic. (e.g. publish `geometry_msgs/Pose` msg from `msg.pose.pose` field of `/odom` topic with `nav_msgs/Odometry`)
+
+Subscriber
+----------
+
+- `~input` (Anymessage)
+
+  Input topic and subtopic field. ( If you want to use `msg.pose.pose` field of `/odom` topic, set this to `/odom/pose/pose` )
+
+Publisher
+---------
+
+- `~output` (Type of subtopic)
+
+  Output topic

--- a/jsk_topic_tools/scripts/extract_subtopic.py
+++ b/jsk_topic_tools/scripts/extract_subtopic.py
@@ -11,20 +11,34 @@ class ExtractSubtopic(object):
 
         topic = rospy.resolve_name('~input')
         real_msg_class, real_topic, msg_eval = rostopic.get_topic_class(topic)
-        rospy.logdebug('topic: {}, real_topic: {}'.format(topic, real_topic))
-        rospy.logdebug('Wating for a message from real_topic for publisher message type.')
+        rospy.loginfo('topic: {}, real_topic: {}'.format(topic, real_topic))
+        rospy.loginfo('Wating for a message from real_topic for publisher message type.')
         msg = rospy.wait_for_message(real_topic, real_msg_class)
         msg_subtopic = msg_eval(msg)
         sub_msg_class = type(msg_subtopic)
-        rospy.logdebug('publisher message type: {}'.format(sub_msg_class))
+        rospy.loginfo('subtopic message type: {}'.format(sub_msg_class))
         try:
             self.msg_eval = msg_eval
             self.pub = rospy.Publisher('~output', sub_msg_class, queue_size=1)
-            self.sub = rospy.Subscriber(real_topic, real_msg_class, self.callback)
         except ValueError:
-            rospy.logerr('Invalid subtopic message type: {}'.format(sub_msg_class))
-            sys.exit(1)
-        rospy.logdebug('initialized')
+            if sub_msg_class is str:
+                import std_msgs.msg
+                sub_msg_class = std_msgs.msg.String
+                self.pub = rospy.Publisher('~output', sub_msg_class, queue_size=1)
+                self.msg_eval_real = self.msg_eval
+                self.msg_eval = lambda msg_real: sub_msg_class(data=self.msg_eval_real(msg_real))
+            elif sub_msg_class is bool:
+                import std_msgs.msg
+                sub_msg_class = std_msgs.msg.Bool
+                self.pub = rospy.Publisher('~output', sub_msg_class, queue_size=1)
+                self.msg_eval_real = self.msg_eval
+                self.msg_eval = lambda msg_real: sub_msg_class(data=self.msg_eval_real(msg_real))
+            else:
+                rospy.logerr('Invalid subtopic message type: {}'.format(sub_msg_class))
+                sys.exit(1)
+        rospy.loginfo('Publisher message type: {}'.format(sub_msg_class))
+        self.sub = rospy.Subscriber(real_topic, real_msg_class, self.callback)
+        rospy.loginfo('initialized')
 
     def callback(self, msg):
 

--- a/jsk_topic_tools/scripts/extract_subtopic.py
+++ b/jsk_topic_tools/scripts/extract_subtopic.py
@@ -2,6 +2,7 @@
 
 import rospy
 import rostopic
+import sys
 
 
 class ExtractSubtopic(object):
@@ -10,12 +11,20 @@ class ExtractSubtopic(object):
 
         topic = rospy.resolve_name('~input')
         real_msg_class, real_topic, msg_eval = rostopic.get_topic_class(topic)
+        rospy.logdebug('topic: {}, real_topic: {}'.format(topic, real_topic))
+        rospy.logdebug('Wating for a message from real_topic for publisher message type.')
         msg = rospy.wait_for_message(real_topic, real_msg_class)
         msg_subtopic = msg_eval(msg)
         sub_msg_class = type(msg_subtopic)
-        self.msg_eval = msg_eval
-        self.pub = rospy.Publisher('~output', sub_msg_class, queue_size=1)
-        self.sub = rospy.Subscriber(real_topic, real_msg_class, self.callback)
+        rospy.logdebug('publisher message type: {}'.format(sub_msg_class))
+        try:
+            self.msg_eval = msg_eval
+            self.pub = rospy.Publisher('~output', sub_msg_class, queue_size=1)
+            self.sub = rospy.Subscriber(real_topic, real_msg_class, self.callback)
+        except ValueError:
+            rospy.logerr('Invalid subtopic message type: {}'.format(sub_msg_class))
+            sys.exit(1)
+        rospy.logdebug('initialized')
 
     def callback(self, msg):
 

--- a/jsk_topic_tools/scripts/extract_subtopic.py
+++ b/jsk_topic_tools/scripts/extract_subtopic.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+import rospy
+import rostopic
+
+
+class ExtractSubtopic(object):
+
+    def __init__(self):
+
+        topic = rospy.resolve_name('~input')
+        real_msg_class, real_topic, msg_eval = rostopic.get_topic_class(topic)
+        msg = rospy.wait_for_message(real_topic, real_msg_class)
+        msg_subtopic = msg_eval(msg)
+        sub_msg_class = type(msg_subtopic)
+        self.msg_eval = msg_eval
+        self.pub = rospy.Publisher('~output', sub_msg_class, queue_size=1)
+        self.sub = rospy.Subscriber(real_topic, real_msg_class, self.callback)
+
+    def callback(self, msg):
+
+        msg_subtopic = self.msg_eval(msg)
+        self.pub.publish(msg_subtopic)
+
+
+if __name__ == '__main__':
+
+    rospy.init_node('extract_subtopic')
+    node = ExtractSubtopic()
+    rospy.spin()

--- a/jsk_topic_tools/scripts/extract_subtopic.py
+++ b/jsk_topic_tools/scripts/extract_subtopic.py
@@ -3,6 +3,8 @@
 import rospy
 import rostopic
 import sys
+import genpy
+import std_msgs.msg
 
 
 class ExtractSubtopic(object):
@@ -22,14 +24,32 @@ class ExtractSubtopic(object):
             self.pub = rospy.Publisher('~output', sub_msg_class, queue_size=1)
         except ValueError:
             if sub_msg_class is str:
-                import std_msgs.msg
                 sub_msg_class = std_msgs.msg.String
                 self.pub = rospy.Publisher('~output', sub_msg_class, queue_size=1)
                 self.msg_eval_real = self.msg_eval
                 self.msg_eval = lambda msg_real: sub_msg_class(data=self.msg_eval_real(msg_real))
             elif sub_msg_class is bool:
-                import std_msgs.msg
                 sub_msg_class = std_msgs.msg.Bool
+                self.pub = rospy.Publisher('~output', sub_msg_class, queue_size=1)
+                self.msg_eval_real = self.msg_eval
+                self.msg_eval = lambda msg_real: sub_msg_class(data=self.msg_eval_real(msg_real))
+            elif sub_msg_class is int:
+                sub_msg_class = std_msgs.msg.Int32
+                self.pub = rospy.Publisher('~output', sub_msg_class, queue_size=1)
+                self.msg_eval_real = self.msg_eval
+                self.msg_eval = lambda msg_real: sub_msg_class(data=self.msg_eval_real(msg_real))
+            elif sub_msg_class is float:
+                sub_msg_class = std_msgs.msg.Float32
+                self.pub = rospy.Publisher('~output', sub_msg_class, queue_size=1)
+                self.msg_eval_real = self.msg_eval
+                self.msg_eval = lambda msg_real: sub_msg_class(data=self.msg_eval_real(msg_real))
+            elif sub_msg_class is genpy.rostime.Time:
+                sub_msg_class = std_msgs.msg.Time
+                self.pub = rospy.Publisher('~output', sub_msg_class, queue_size=1)
+                self.msg_eval_real = self.msg_eval
+                self.msg_eval = lambda msg_real: sub_msg_class(data=self.msg_eval_real(msg_real))
+            elif sub_msg_class is genpy.rostime.Duration:
+                sub_msg_class = std_msgs.msg.Duration
                 self.pub = rospy.Publisher('~output', sub_msg_class, queue_size=1)
                 self.msg_eval_real = self.msg_eval
                 self.msg_eval = lambda msg_real: sub_msg_class(data=self.msg_eval_real(msg_real))


### PR DESCRIPTION
Add extract_subtopic.py

This node can publish sub-field of input topic. (e.g. publish `geometry_msgs/Pose` msg from `msg.pose.pose` field of `/odom` topic with `nav_msgs/Odometry`)

e.g.

When we have a `/imu` topic like below,

```bash
sktometometo@fetch1075
[gitbranch:]
[ROS VERSION:1]
[ROS workspace:/home/sktometometo/ros/ws_main]
[04:20 午後 火  7月 05]
~ $ rostopic echo /imu -n 1
rostopic: topic is [/imu]
real_topic: /imu
header:
  seq: 4435709
  stamp:
    secs: 1657005643
    nsecs: 941799347
  frame_id: "base_link"
orientation:
  x: 0.0
  y: 0.0
  z: 0.0
  w: 0.0
orientation_covariance: [-1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
angular_velocity:
  x: 0.0
  y: 0.0
  z: 0.0
angular_velocity_covariance: [4e-06, 0.0, 0.0, 0.0, 4e-06, 0.0, 0.0, 0.0, 4e-06]
linear_acceleration:
  x: 0.0
  y: -0.613143552
  z: 9.96358272
linear_acceleration_covariance: [0.34644996, 0.0, 0.0, 0.0, 0.34644996, 0.0, 0.0, 0.0, 0.34644996]
---
```

And run this node like

```bash
sktometometo@fetch1075
[gitbranch:]
[ROS VERSION:1]
[ROS workspace:/home/sktometometo/ros/ws_main]
[04:20 午後 火  7月 05]
~ $ rosrun jsk_topic_tools extract_subtopic.py ~input:=/imu/orientation
```

We can have another topic `/extract_subtopic/output` with `geometry_msgs/Quaternion`

```bash
sktometometo@fetch1075
[gitbranch:]
[ROS VERSION:1]
[ROS workspace:/home/sktometometo/ros/ws_main]
[04:22 午後 火  7月 05]
~ $ rostopic echo /extract_subtopic/output -n 1
rostopic: topic is [/extract_subtopic/output]
real_topic: /extract_subtopic/output
x: 0.0
y: 0.0
z: 0.0
w: 0.0
---
```