### PR TITLE
[jsk_rosbag_tools] Fixed a bug when the specified fps is less than the fps of the topic in rosbag.

### DIFF
--- a/jsk_rosbag_tools/python/jsk_rosbag_tools/bag_to_video.py
+++ b/jsk_rosbag_tools/python/jsk_rosbag_tools/bag_to_video.py
@@ -136,14 +136,14 @@ def bag_to_video(input_bagfile,
             if show_progress_bar:
                 progress.update(1)
             aligned_stamp = stamp - start_stamp
+            # write the current image until the next frame's timestamp.
             while current_time < aligned_stamp:
                 current_time += dt
                 writer.write_frame(cur_img)
+            # set current image.
             cur_img = resize_keeping_aspect_ratio_wrt_target_size(
                 cv2.cvtColor(bgr_img, cv2.COLOR_BGR2RGB),
                 width=width, height=height)
-            writer.write_frame(cur_img)
-            current_time += dt
         writer.close()
 
         if show_progress_bar:


### PR DESCRIPTION
# What is this?

Now if the specified fps is lower than the hz of the topic in the rosbag, the video generation will not work.
https://drive.google.com/uc?id=1Py0x0Ys0O6M5O0D1oexYSrvEx-5z6Iue

This PR fixed a bug when the specified fps is less than the fps of the topic in rosbag.

- [x] Add test for fps.