### PR TITLE
[jsk_topic_tools/timered_diagnostics_updater] Use force_update instead of update because of update called using TimeredDiagnosticUpdater's timer

### DIFF
--- a/jsk_topic_tools/src/timered_diagnostic_updater.cpp
+++ b/jsk_topic_tools/src/timered_diagnostic_updater.cpp
@@ -77,7 +77,9 @@ namespace jsk_topic_tools
 
   void TimeredDiagnosticUpdater::update()
   {
-    diagnostic_updater_->update();
+    // Since TimedDiagnosticUpdater is already managed as a timer,
+    // diagnostic_updater_->force_update is executed instead of diagnostic_updater_->update.
+    diagnostic_updater_->force_update();
   }
   
   void TimeredDiagnosticUpdater::timerCallback(const ros::TimerEvent& event)


### PR DESCRIPTION
# What is this?

The timed diagnostic updater used in `DiagnosticNodelet` and `relaynodelet` updates the diagnostic for a predetermined duration using timer.
However, the diagnostic_updater that TimeredDiagnosticUpdater has determines whether an update is actually performed based on its own timer in the update function.
https://github.com/ros/diagnostics/blob/dbc73ff508813ec13eaf23594006ccb9b61d083c/diagnostic_updater/include/diagnostic_updater/diagnostic_updater.h#L383-L392

```
      void update()
      {
        ros::Time now_time = ros::Time::now();
        if (now_time < next_time_) {
          // @todo put this back in after fix of #2157 update_diagnostic_period(); // Will be checked in force_update otherwise.
          return;
        }

        force_update();
      }
```
Since TimedDiagnosticUpdater is already managed as a timer, diagnostic_updater_->force_update should be executed instead of diagnostic_updater_->update.

cc: @708yamaguchi 