### PR TITLE
[jsk_topic_tools] Add header file to check jsk_topic_tools' version

### DIFF
--- a/jsk_topic_tools/CMakeLists.txt
+++ b/jsk_topic_tools/CMakeLists.txt
@@ -234,6 +234,7 @@ install(FILES
 
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h" # Ignore *_version.h.in files
 )
 
 install(DIRECTORY scripts/

--- a/jsk_topic_tools/CMakeLists.txt
+++ b/jsk_topic_tools/CMakeLists.txt
@@ -31,6 +31,21 @@ configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/jsk_topic_tools/nodelet_version.h.in
   ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION}/jsk_topic_tools/nodelet_version.h)
 
+catkin_package_xml()
+# split version in parts and pass to extra file
+string(REPLACE "." ";" jsk_topic_tools_VERSION_LIST "${jsk_topic_tools_VERSION}")
+list(LENGTH jsk_topic_tools_VERSION_LIST _count)
+if(NOT _count EQUAL 3)
+  message(FATAL_ERROR "jsk_topic_tools version '${jsk_topic_tools_VERSION}' does not match 'MAJOR.MINOR.PATCH' pattern")
+endif()
+list(GET jsk_topic_tools_VERSION_LIST 0 jsk_topic_tools_VERSION_MAJOR)
+list(GET jsk_topic_tools_VERSION_LIST 1 jsk_topic_tools_VERSION_MINOR)
+list(GET jsk_topic_tools_VERSION_LIST 2 jsk_topic_tools_VERSION_PATCH)
+
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/jsk_topic_tools/jsk_topic_tools_version.h.in
+  ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION}/jsk_topic_tools/jsk_topic_tools_version.h)
+
 # download and install sample data
 catkin_download(download_sample_pr2_wrench-2022-05-02 https://drive.google.com/uc?id=1ym_fxRTNZOTp4PCXIq_spJwFktoOkLDK
   DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/sample/data

--- a/jsk_topic_tools/include/jsk_topic_tools/jsk_topic_tools_version.h.in
+++ b/jsk_topic_tools/include/jsk_topic_tools/jsk_topic_tools_version.h.in
@@ -1,0 +1,48 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2022, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#ifndef JSK_TOPIC_TOOLS_VERSION_
+#define JSK_TOPIC_TOOLS_VERSION_
+
+#define JSK_TOPIC_TOOLS_VERSION_MAJOR @jsk_topic_tools_VERSION_MAJOR@
+#define JSK_TOPIC_TOOLS_VERSION_MINOR @jsk_topic_tools_VERSION_MINOR@
+#define JSK_TOPIC_TOOLS_VERSION_PATCH @jsk_topic_tools_VERSION_PATCH@
+#define JSK_TOPIC_TOOLS_VERSION_COMBINED(major, minor, patch) (((major) << 20) | ((minor) << 10) | (patch))
+#define JSK_TOPIC_TOOLS_VERSION JSK_TOPIC_TOOLS_VERSION_COMBINED(JSK_TOPIC_TOOLS_VERSION_MAJOR, JSK_TOPIC_TOOLS_VERSION_MINOR, JSK_TOPIC_TOOLS_VERSION_PATCH)
+
+#define JSK_TOPIC_TOOLS_GE(major1, minor1, patch1, major2, minor2, patch2) (JSK_TOPIC_TOOLS_VERSION_COMBINED(major1, minor1, patch1) >= JSK_TOPIC_TOOLS_VERSION_COMBINED(major2, minor2, patch2))
+#define JSK_TOPIC_TOOLS_MINIMUM(major, minor, patch) JSK_TOPIC_TOOLS_GE(JSK_TOPIC_TOOLS_VERSION_MAJOR, JSK_TOPIC_TOOLS_VERSION_MINOR, JSK_TOPIC_TOOLS_VERSION_PATCH, major, minor, patch)
+
+#endif


### PR DESCRIPTION
# What is this?

I add `version.h` for `jsk_topic_tools` to check version for build.
`jsk_topic_tools` has base class such as `DiagnosticNodelet` and `ConnectionBasedNodelet`.
For example, nodes in `jsk_recognition` are using those notelets.

This PR is useful to check `jsk_topic_tools` version.

Related to https://github.com/jsk-ros-pkg/jsk_recognition/pull/2712