### PR TITLE
[jsk_topic_tools/HzMeasureNodelet] Modified to measure hz in the updateDiagnostics function.

### DIFF
--- a/jsk_topic_tools/include/jsk_topic_tools/hz_measure_nodelet.h
+++ b/jsk_topic_tools/include/jsk_topic_tools/hz_measure_nodelet.h
@@ -52,7 +52,6 @@ namespace jsk_topic_tools
     virtual void onInit();
   protected:
     int average_message_num_;
-    double hz_;
     double warning_hz_;
     std::queue<ros::Time> buffer_;
     ros::Publisher hz_pub_;


### PR DESCRIPTION
# What is this?

Since the `hz` is now calculated in the callback function, 
so if topic stops for a while, the `hz` calculation will not be correct.

With this PR, the `hz` calculation will be correct even if the topic does not come.