### PR TITLE
[jsk_tools/sanity_diagnostics.py] Modified the timing of updating

### DIFF
--- a/jsk_tools/src/sanity_diagnostics.py
+++ b/jsk_tools/src/sanity_diagnostics.py
@@ -36,19 +36,23 @@ class SanityDiagnostics(object):
         # Set diagnostic updater for each topic and node
         self.updater = diagnostic_updater.Updater()
         self.updater.setHardwareID("none")
+        self.last_time_check_topic = {}
+        self.last_time_check_node = {}
+        # Topic and node status
+        self.topic_state = {}
+        self.node_state = {}
         for topic_name in topics:
             self.updater.add(
                 topic_name,
                 lambda stat, tn=topic_name: self.check_topic(stat, tn))
+            self.last_time_check_topic[topic_name] = rospy.Time.now()
+            self.topic_state[topic_name] = True
         for node_name in nodes:
             self.updater.add(
                 node_name,
                 lambda stat, nn=node_name: self.check_node(stat, nn))
-        # Topic and node status
-        self.topic_state = True
-        self.node_state = True
-        self.last_time_check_topic = rospy.Time.now()
-        self.last_time_check_node = rospy.Time.now()
+            self.last_time_check_node[node_name] = rospy.Time.now()
+            self.node_state[node_name] = True
         # Timer to call updater
         self.timer = rospy.Timer(
             rospy.Duration(pub_duration), self.pub_diagnostics)
@@ -57,24 +61,25 @@ class SanityDiagnostics(object):
         self.updater.update()
 
     def check_topic(self, stat, topic_name):
-        elapsed_time = rospy.Time.now() - self.last_time_check_topic
+        elapsed_time = rospy.Time.now() - self.last_time_check_topic[topic_name]
         if elapsed_time.secs > self.check_duration:
             # Assume that topic is published at more than (1.0 / timeout) Hz
-            self.topic_state = checkTopicIsPublished(topic_name, timeout=10)
-            self.last_time_check_topic = rospy.Time.now()
-        if self.topic_state:
+            self.topic_state[topic_name] = checkTopicIsPublished(
+                topic_name, timeout=10)
+            self.last_time_check_topic[topic_name] = rospy.Time.now()
+        if self.topic_state[topic_name]:
             stat.summary(DiagnosticStatus.OK, 'Topic is published')
         else:
             stat.summary(DiagnosticStatus.ERROR, 'Topic is not published')
         return stat
 
     def check_node(self, stat, node_name):
-        elapsed_time = rospy.Time.now() - self.last_time_check_node
+        elapsed_time = rospy.Time.now() - self.last_time_check_node[node_name]
         if elapsed_time.secs > self.check_duration:
             # Assume that topic is published at more than (1.0 / timeout) Hz
-            self.node_state = checkNodeState(node_name, needed=True)
-            self.last_time_check_node = rospy.Time.now()
-        if self.node_state:
+            self.node_state[node_name] = checkNodeState(node_name, needed=True)
+            self.last_time_check_node[node_name] = rospy.Time.now()
+        if self.node_state[node_name]:
             stat.summary(DiagnosticStatus.OK, 'Node is alive')
         else:
             stat.summary(DiagnosticStatus.ERROR, 'Node is dead')


### PR DESCRIPTION
# What is this?

Modified the timing of updating timestamp and states for each topic and each node.

Now all topics are managed in one timestamp, so when one topic is updated, the others are not checked.
This PR checks each topic correctly by maintaining a timestamp for each topic.

This PR is tested on PR1040 https://github.com/knorth55/jsk_common/pull/25
