### PR TITLE
[jsk_topic_tools] Eval at every timer callback

### DIFF
--- a/doc/jsk_topic_tools/scripts/boolean_node.rst
+++ b/doc/jsk_topic_tools/scripts/boolean_node.rst
@@ -72,6 +72,8 @@ Parameters
 
     input1_condition: "(rospy.Time.now() - t).to_sec() &lt; 1.0"
 
+  Use escape sequence when using the following symbols <(``&lt;``), >(``&gt;``), &(``&amp;``), '(``&apos;``) and "(``&quot;``) in launch file.
+
 
 * ``~rate`` (Int, Default: ``100``)
 

--- a/doc/jsk_topic_tools/scripts/boolean_node.rst
+++ b/doc/jsk_topic_tools/scripts/boolean_node.rst
@@ -66,6 +66,13 @@ Parameters
     input1_condition: m.header.frame_id in ['base', 'base_link']
 
 
+  Note that this condition is evaluated each time a topic is published. For example, a condition that checks whether a certain topic has arrived within one second look like this.
+
+  .. code-block:: bash
+
+    input1_condition: "(rospy.Time.now() - t).to_sec() &lt; 1.0"
+
+
 * ``~rate`` (Int, Default: ``100``)
 
   Publishing rate [Hz].


### PR DESCRIPTION
# What is this?

Changed boolean node to evaluate condition each time a topic is published.
For example, a condition that checks whether a certain topic has arrived within one second look like this.

```
  <node name="shutdown_selector"
        pkg="jsk_topic_tools" type="boolean_node.py"
        output="screen"
        clear_params="true"
        respawn="true" >
    <remap from="~input1" to="$(arg battery_state_topic)" />
    <remap from="~input2" to="$(arg shutdown_unchecked_topic)" />
    <remap from="~output/and" to="/execute_shutdown" />
    <rosparam>
      number_of_input: 2
      input1_condition: "m.is_charging is False"
      input2_condition: "(rospy.Time.now() - t).to_sec() &lt; 1.0"
    </rosparam>
  </node>
```

## Use case
https://github.com/jsk-ros-pkg/jsk_robot/pull/1570
