### PR TITLE
[jsk_topic_tools/DiagnosticsNodelet] Enable constructor without name argument

### DIFF
--- a/jsk_topic_tools/include/jsk_topic_tools/diagnostic_nodelet.h
+++ b/jsk_topic_tools/include/jsk_topic_tools/diagnostic_nodelet.h
@@ -69,6 +69,11 @@ namespace jsk_topic_tools
 
     /** @brief
      * Constructor and subclass need to call this.
+     */
+    DiagnosticNodelet();
+
+    /** @brief
+     * Constructor and subclass need to call this.
      *
      * @param name name of subclass
      */

--- a/jsk_topic_tools/src/diagnostic_nodelet.cpp
+++ b/jsk_topic_tools/src/diagnostic_nodelet.cpp
@@ -37,6 +37,10 @@
 #include <sstream>
 namespace jsk_topic_tools
 {
+
+  DiagnosticNodelet::DiagnosticNodelet():
+    name_(getName()) {}
+
   DiagnosticNodelet::DiagnosticNodelet(const std::string& name):
     name_(name)
   {


### PR DESCRIPTION
# What is this?

Related to https://github.com/jsk-ros-pkg/jsk_recognition/pull/2712
The jsk nodes use `ConnectionBasedNodelet` and `DiagnosticsNodelet`.

https://github.com/jsk-ros-pkg/jsk_recognition/pull/2712#discussion_r918957879
If we want to write the following, we need to create a constructor with no arguments in DiagnosticsNodelet.
```
#if  defined(JSK_TOPIC_TOOLS_VERSION) and JKS_NODELET_VERSION_MINIMUM(2,2,13))
    #define jsk_topic_tools::NODLET jsk_topic_tools::ConnectionBasedNodelet
#else
    #define jsk_topic_tools::NODLET jsk_topic_tools::DiagnosticNodelet
#endif```