### PR TITLE
[jsk_topic_tools/DiagnosticNodelet] Use node name for diagnostic message

### DIFF
--- a/jsk_topic_tools/src/diagnostic_nodelet.cpp
+++ b/jsk_topic_tools/src/diagnostic_nodelet.cpp
@@ -55,7 +55,7 @@ namespace jsk_topic_tools
       new TimeredDiagnosticUpdater(*pnh_, ros::Duration(1.0)));
     diagnostic_updater_->setHardwareID(getName());
     diagnostic_updater_->add(
-      getName() + "::" + name_,
+      getName(),
       boost::bind(
         &DiagnosticNodelet::updateDiagnostic,
         this,
@@ -94,7 +94,7 @@ namespace jsk_topic_tools
       }
       else {
         jsk_topic_tools::addDiagnosticErrorSummary(
-          name_, vital_checker_, stat, diagnostic_error_level_);
+          getName(), vital_checker_, stat, diagnostic_error_level_);
       }
     }
     else {

--- a/jsk_topic_tools/src/diagnostic_utils.cpp
+++ b/jsk_topic_tools/src/diagnostic_utils.cpp
@@ -60,7 +60,7 @@ namespace jsk_topic_tools
   {
     stat.summary(
       error_level,
-      (boost::format("%s not running for %f sec")
+      (boost::format("%s not running for %.1f sec")
        % string_prefix % vital_checker->deadSec()).str());
   }
   


### PR DESCRIPTION
# What is this?

Related to https://github.com/jsk-ros-pkg/jsk_recognition/pull/2712 and https://github.com/jsk-ros-pkg/jsk_common/pull/1761
The DiagnosticNodelet outputs diagnostic messages.

However, the name has been specified by the developer.　https://github.com/jsk-ros-pkg/jsk_common/pull/1761
[This PR](https://github.com/jsk-ros-pkg/jsk_recognition/pull/2712) allows the user to use connection based nodelets and diagnostics nodelets depending on the version of jsk_topic_tools.

I have also changed the format to make the numbers easier to read.

[jsk_recognition package's PR](https://github.com/jsk-ros-pkg/jsk_recognition/pull/2712) assumes that these changes will be incorporated in the next released version (`2.2.13`).


