### PR TITLE
fix: make battery_capacity_summary compatible with python3

### DIFF
--- a/jsk_tools/bin/battery_capacity_summary.py
+++ b/jsk_tools/bin/battery_capacity_summary.py
@@ -56,8 +56,8 @@ def output():
     sorted_keys = ["HardwareID"] + sorted(data_column.keys())
     sorted_names = sorted(results)
     fmt = "{:>31}"
-    for i in range(len(data_column.keys())):
-        fmt += "| {:>" + "{w}".format(w=len(data_column.keys()[i])) + "}"
+    for key in data_column.keys():
+        fmt += "| {:>" + "{w}".format(w=len(key)) + "}"
     print(fmt.format("Battery Name", *data_column.keys()))
     for name in sorted_names:
         color = getColor(results[name])


### PR DESCRIPTION
Checked both using python3 (my machine) and python2 (inside pr1040).

On noetic (python3.8) before this PR.
```
[http://pr1040:11311][133.11.216.116] h-ishida@stone-jsk:~$ rosrun jsk_tools battery_capacity_summary.py 
aggregating battery info...
Traceback (most recent call last):
  File "/opt/ros/noetic/lib/jsk_tools/battery_capacity_summary.py", line 76, in <module>
    output()
  File "/opt/ros/noetic/lib/jsk_tools/battery_capacity_summary.py", line 60, in output
    fmt += "| {:>" + "{w}".format(w=len(data_column.keys()[i])) + "}"
TypeError: 'odict_keys' object is not subscriptable
```

After this PR
```
[http://pr1040:11311][133.11.216.116] h-ishida@stone-jsk:~/catkin_ws/src/jsk_common/jsk_tools$ python3 bin/battery_capacity_summary.py 
aggregating battery info...
                   Battery Name| Serial| ManufactureDate| FullCapacity(mAh)| RemainingCapacity(mAh)| Voltage(mV)| CycleCount| Status
/Power System/Smart Battery 0.0|  24842|      11/27/2017|              6825|                   6809|       16721|         36|    224
/Power System/Smart Battery 0.1|  24840|      11/27/2017|              6868|                   6851|       16721|         34|    224
/Power System/Smart Battery 0.2|  24843|      11/27/2017|              6657|                   6642|       16721|         37|    224
/Power System/Smart Battery 0.3|  24844|      11/27/2017|              6827|                   6813|       16721|         37|    224
/Power System/Smart Battery 1.0|  24833|      11/27/2017|              6730|                   6708|       16700|         63|    224
/Power System/Smart Battery 1.1|  24820|      11/27/2017|              7039|                   6711|       16392|         54|      0
/Power System/Smart Battery 1.2|  24825|      11/27/2017|              6479|                   6468|       16594|         63|    224
/Power System/Smart Battery 1.3|  24836|      11/27/2017|              6607|                   6578|       16708|         65|    224
/Power System/Smart Battery 2.0|  24828|      11/27/2017|              5998|                   5992|       16614|        154|    224
/Power System/Smart Battery 2.1|  24838|      11/27/2017|              6294|                   6293|       16667|        152|    224
/Power System/Smart Battery 2.2|  24837|      11/27/2017|              6296|                   6296|       16672|        155|    224
/Power System/Smart Battery 2.3|  24821|      11/27/2017|              6187|                   5911|       16670|        155|      0
/Power System/Smart Battery 3.0|    N/A|             N/A|               N/A|                   2151|       16593|        N/A|    224
/Power System/Smart Battery 3.1|    N/A|             N/A|               N/A|                   4288|       16075|        N/A|  16576
/Power System/Smart Battery 3.2|  24824|      11/27/2017|              4422|                   4422|       16544|        175|    224
/Power System/Smart Battery 3.3|  24818|      11/27/2017|              1295|                   1295|       16571|        176|      0
```