### PR TITLE
catch StopIteration when all images do not have stamp

### DIFF
--- a/jsk_rosbag_tools/python/jsk_rosbag_tools/bag_to_video.py
+++ b/jsk_rosbag_tools/python/jsk_rosbag_tools/bag_to_video.py
@@ -110,10 +110,15 @@ def bag_to_video(input_bagfile,
 
         # remove 0 time stamp
         stamp = 0.0
-        while stamp == 0.0:
-            stamp, _, img, _ = next(images)
-            if show_progress_bar:
-                progress.update(1)
+        try:
+            while stamp == 0.0:
+                stamp, _, img, _ = next(images)
+                if show_progress_bar:
+                    progress.update(1)
+        except StopIteration:
+            print('[bag_to_video] No timestamp found in all images')
+            print('[bag_to_video] Skipping {}'.format(image_topic))
+            break
         start_stamp = stamp
         width, height = img.shape[1], img.shape[0]
 


### PR DESCRIPTION
`bag_to_video` throw `StopInteration` signal when there is no `next` in iterator.
This occurs when all images has 0 timestamp.
This PR avoid the error and skip the topic when all timestamp is zero.