### PR TITLE
[ROS-O] do not specify c++ standard

### DIFF
--- a/jsk_network_tools/setup.py
+++ b/jsk_network_tools/setup.py
@@ -1,6 +1,6 @@
 ## ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml

--- a/jsk_ros_patch/image_view2/CMakeLists.txt
+++ b/jsk_ros_patch/image_view2/CMakeLists.txt
@@ -11,12 +11,6 @@ if (CMAKE_VERSION VERSION_LESS 3.4)
   endif(CCACHE_FOUND)
 endif()
 
-if(NOT $ENV{ROS_DISTRO} STRLESS noetic)
-  add_compile_options(-std=c++14)
-elseif(NOT $ENV{ROS_DISTRO} STRLESS kinetic)
-  add_compile_options(-std=c++11)
-endif()
-
 find_package(catkin REQUIRED COMPONENTS roscpp dynamic_reconfigure  cv_bridge std_msgs sensor_msgs geometry_msgs image_transport tf image_geometry message_filters message_generation std_srvs pcl_ros)
 
 generate_dynamic_reconfigure_options(

--- a/jsk_ros_patch/image_view2/image_view2.cpp
+++ b/jsk_ros_patch/image_view2/image_view2.cpp
@@ -116,7 +116,7 @@ namespace image_view2{
 
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> >(local_nh);
     dynamic_reconfigure::Server<Config>::CallbackType f =
-      boost::bind(&ImageView2::config_callback, this, _1, _2);
+      [this](auto& config, auto level){ config_callback(config, level); };
     srv_->setCallback(f);
   }
 

--- a/jsk_ros_patch/image_view2/points_rectangle_extractor.cpp
+++ b/jsk_ros_patch/image_view2/points_rectangle_extractor.cpp
@@ -43,11 +43,11 @@ public:
 
     sync_a_polygon_ = boost::make_shared < message_filters::Synchronizer< PolygonApproxSyncPolicy > > (queue_size);
     sync_a_polygon_->connectInput (points_sub_, rect_sub_);
-    sync_a_polygon_->registerCallback (boost::bind (&PointsRectExtractor::callback_polygon, this, _1, _2));
+    sync_a_polygon_->registerCallback (boost::bind (&PointsRectExtractor::callback_polygon, this, boost::placeholders::_1, boost::placeholders::_2));
 
     sync_a_point_ = boost::make_shared < message_filters::Synchronizer< PointApproxSyncPolicy > > (queue_size);
     sync_a_point_->connectInput (points_sub_, point_sub_);
-    sync_a_point_->registerCallback (boost::bind (&PointsRectExtractor::callback_point, this, _1, _2));
+    sync_a_point_->registerCallback (boost::bind (&PointsRectExtractor::callback_point, this, boost::placeholders::_1, boost::placeholders::_2));
 
     pub_ = pnode_.advertise< sensor_msgs::PointCloud2 > ("output", 1);
   }

--- a/jsk_tilt_laser/src/spin_laser_snapshotter.cpp
+++ b/jsk_tilt_laser/src/spin_laser_snapshotter.cpp
@@ -103,8 +103,8 @@ public:
       private_ns_.param("spindle_frame", spindle_frame_, std::string("multisense/spindle"));
       private_ns_.param("motor_frame", motor_frame_, std::string("multisense/motor"));
       timer_ = private_ns_.createTimer(
-        ros::Duration(1.0 / rate_), boost::bind(
-          &SpinLaserSnapshotter::timerCallback, this, _1));
+        ros::Duration(1.0 / rate_),
+        [this](auto& event){ timerCallback(event); });
     }
   }
 

--- a/jsk_topic_tools/include/jsk_topic_tools/connection_based_nodelet.h
+++ b/jsk_topic_tools/include/jsk_topic_tools/connection_based_nodelet.h
@@ -192,9 +192,9 @@ namespace jsk_topic_tools
     {
       boost::mutex::scoped_lock lock(connection_mutex_);
       ros::SubscriberStatusCallback connect_cb
-        = boost::bind(&ConnectionBasedNodelet::connectionCallback, this, _1);
+        = [this](auto& pub){ connectionCallback(pub); };
       ros::SubscriberStatusCallback disconnect_cb
-        = boost::bind(&ConnectionBasedNodelet::connectionCallback, this, _1);
+        = [this](auto& pub){ connectionCallback(pub); };
       ros::Publisher ret = nh.advertise<T>(topic, queue_size,
                                            connect_cb,
                                            disconnect_cb,
@@ -254,11 +254,9 @@ namespace jsk_topic_tools
     {
       boost::mutex::scoped_lock lock(connection_mutex_);
       image_transport::SubscriberStatusCallback connect_cb
-        = boost::bind(&ConnectionBasedNodelet::imageConnectionCallback,
-                      this, _1);
+        = [this](auto& pub){ imageConnectionCallback(pub); };
       image_transport::SubscriberStatusCallback disconnect_cb
-        = boost::bind(&ConnectionBasedNodelet::imageConnectionCallback,
-                      this, _1);
+        = [this](auto& pub){ imageConnectionCallback(pub); };
       image_transport::Publisher pub = image_transport::ImageTransport(nh).advertise(
         topic, 1,
         connect_cb,
@@ -318,17 +316,13 @@ namespace jsk_topic_tools
     {
       boost::mutex::scoped_lock lock(connection_mutex_);
       image_transport::SubscriberStatusCallback connect_cb
-        = boost::bind(&ConnectionBasedNodelet::cameraConnectionCallback,
-                      this, _1);
+        = [this](auto& pub){ cameraConnectionCallback(pub); };
       image_transport::SubscriberStatusCallback disconnect_cb
-        = boost::bind(&ConnectionBasedNodelet::cameraConnectionCallback,
-                      this, _1);
+        = [this](auto& pub){ cameraConnectionCallback(pub); };
       ros::SubscriberStatusCallback info_connect_cb
-        = boost::bind(&ConnectionBasedNodelet::cameraInfoConnectionCallback,
-                      this, _1);
+        = [this](auto& pub){ cameraInfoConnectionCallback(pub); };
       ros::SubscriberStatusCallback info_disconnect_cb
-        = boost::bind(&ConnectionBasedNodelet::cameraInfoConnectionCallback,
-                      this, _1);
+        = [this](auto& pub){ cameraInfoConnectionCallback(pub); };
       image_transport::CameraPublisher
         pub = image_transport::ImageTransport(nh).advertiseCamera(
           topic, 1,

--- a/jsk_topic_tools/include/jsk_topic_tools/connection_based_nodelet.h
+++ b/jsk_topic_tools/include/jsk_topic_tools/connection_based_nodelet.h
@@ -86,7 +86,7 @@ namespace jsk_topic_tools
     virtual void onInitPostProcess();
     
     /** @brief
-     * callback function which is called when new subscriber come
+     * callback function which is called when new subscriber connects or disconnects
      */
     virtual void connectionCallback(const ros::SingleSubscriberPublisher& pub);
 

--- a/jsk_topic_tools/src/block_nodelet.cpp
+++ b/jsk_topic_tools/src/block_nodelet.cpp
@@ -31,7 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "jsk_topic_tools/block_nodelet.h"
 
 #include <ros/advertise_options.h>

--- a/jsk_topic_tools/src/deprecated_relay_nodelet.cpp
+++ b/jsk_topic_tools/src/deprecated_relay_nodelet.cpp
@@ -33,7 +33,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "jsk_topic_tools/deprecated_relay.h"
 #include "jsk_topic_tools/log_utils.h"
 namespace jsk_topic_tools

--- a/jsk_topic_tools/src/diagnostic_nodelet.cpp
+++ b/jsk_topic_tools/src/diagnostic_nodelet.cpp
@@ -56,10 +56,7 @@ namespace jsk_topic_tools
     diagnostic_updater_->setHardwareID(getName());
     diagnostic_updater_->add(
       getName() + "::" + name_,
-      boost::bind(
-        &DiagnosticNodelet::updateDiagnostic,
-        this,
-        _1));
+      [this](auto& stat){ updateDiagnostic(stat); });
 
     bool use_warn;
     nh_->param("/diagnostic_nodelet/use_warn", use_warn, false);

--- a/jsk_topic_tools/src/hz_measure_nodelet.cpp
+++ b/jsk_topic_tools/src/hz_measure_nodelet.cpp
@@ -63,9 +63,7 @@ namespace jsk_topic_tools
 
     diagnostic_updater_.reset(new TimeredDiagnosticUpdater(pnh_, ros::Duration(1.0)));
     diagnostic_updater_->setHardwareID(getName());
-    diagnostic_updater_->add(getName(),
-                             boost::bind(&HzMeasure::updateDiagnostic,
-                                         this, _1));
+    diagnostic_updater_->add(getName(), [this](auto& stat){ updateDiagnostic(stat); });
     diagnostic_updater_->start();
 
     hz_pub_ = pnh_.advertise<std_msgs::Float32>("output", 1);

--- a/jsk_topic_tools/src/hz_measure_nodelet.cpp
+++ b/jsk_topic_tools/src/hz_measure_nodelet.cpp
@@ -34,7 +34,7 @@
 
 #include <limits>
 #include <boost/format.hpp>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "jsk_topic_tools/hz_measure_nodelet.h"
 
 #include "std_msgs/Float32.h"

--- a/jsk_topic_tools/src/lightweight_throttle_nodelet.cpp
+++ b/jsk_topic_tools/src/lightweight_throttle_nodelet.cpp
@@ -120,6 +120,6 @@ namespace jsk_topic_tools
   }
 }
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 typedef jsk_topic_tools::LightweightThrottle LightweightThrottle;
 PLUGINLIB_EXPORT_CLASS(LightweightThrottle, nodelet::Nodelet)

--- a/jsk_topic_tools/src/lightweight_throttle_nodelet.cpp
+++ b/jsk_topic_tools/src/lightweight_throttle_nodelet.cpp
@@ -45,7 +45,7 @@ namespace jsk_topic_tools
 
     srv_ = boost::make_shared<dynamic_reconfigure::Server<Config> >(pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
-      boost::bind(&LightweightThrottle::configCallback, this, _1, _2);
+      [this](auto& config, auto level){ configCallback(config, level); };
     srv_->setCallback(f);
 
     // Subscribe input topic at first in order to decide
@@ -95,7 +95,7 @@ namespace jsk_topic_tools
       // This section should be called once
       sub_->shutdown();         // Shutdown before advertising topic
       ros::SubscriberStatusCallback connect_cb
-        = boost::bind(&LightweightThrottle::connectionCallback, this, _1);
+        = [this](auto& pub){ connectionCallback(pub); };
       ros::AdvertiseOptions opts("output", 1,
                                  msg->getMD5Sum(),
                                  msg->getDataType(),

--- a/jsk_topic_tools/src/mux_nodelet.cpp
+++ b/jsk_topic_tools/src/mux_nodelet.cpp
@@ -31,7 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "jsk_topic_tools/mux_nodelet.h"
 #include <std_msgs/String.h>
 #include "jsk_topic_tools/rosparam_utils.h"

--- a/jsk_topic_tools/src/mux_nodelet.cpp
+++ b/jsk_topic_tools/src/mux_nodelet.cpp
@@ -194,7 +194,7 @@ namespace jsk_topic_tools
   {
     if (!advertised_) {         // first time
       ros::SubscriberStatusCallback connect_cb
-        = boost::bind(&MUX::connectCb, this, _1);
+        = [this](auto& pub){ connectCb(pub); };
       ros::AdvertiseOptions opts("output", 1,
                                  msg->getMD5Sum(),
                                  msg->getDataType(),

--- a/jsk_topic_tools/src/passthrough_nodelet.cpp
+++ b/jsk_topic_tools/src/passthrough_nodelet.cpp
@@ -31,7 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "jsk_topic_tools/passthrough_nodelet.h"
 
 namespace jsk_topic_tools

--- a/jsk_topic_tools/src/relay_nodelet.cpp
+++ b/jsk_topic_tools/src/relay_nodelet.cpp
@@ -31,7 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "jsk_topic_tools/relay_nodelet.h"
 
 namespace jsk_topic_tools

--- a/jsk_topic_tools/src/relay_nodelet.cpp
+++ b/jsk_topic_tools/src/relay_nodelet.cpp
@@ -50,8 +50,7 @@ namespace jsk_topic_tools
     diagnostic_updater_->setHardwareID(getName());
     diagnostic_updater_->add(
       getName() + "::Relay",
-      boost::bind(
-        &Relay::updateDiagnostic, this, _1));
+      [this](auto& stat){ updateDiagnostic(stat); });
     double vital_rate;
     pnh_.param("vital_rate", vital_rate, 1.0);
     vital_checker_.reset(

--- a/jsk_topic_tools/src/snapshot_nodelet.cpp
+++ b/jsk_topic_tools/src/snapshot_nodelet.cpp
@@ -101,5 +101,5 @@ namespace jsk_topic_tools
   
 }
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS (jsk_topic_tools::Snapshot, nodelet::Nodelet);

--- a/jsk_topic_tools/src/stealth_relay_nodelet.cpp
+++ b/jsk_topic_tools/src/stealth_relay_nodelet.cpp
@@ -69,7 +69,7 @@ namespace jsk_topic_tools
 
     srv_ = boost::make_shared<dynamic_reconfigure::Server<Config> >(*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
-      boost::bind(&StealthRelay::configCallback, this, _1, _2);
+      [this](auto& config, auto level){ configCallback(config, level); };
     srv_->setCallback(f);
 
     /* To advertise output topic as the same type of input topic,

--- a/jsk_topic_tools/src/stealth_relay_nodelet.cpp
+++ b/jsk_topic_tools/src/stealth_relay_nodelet.cpp
@@ -197,6 +197,6 @@ namespace jsk_topic_tools
   }
 }
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 typedef jsk_topic_tools::StealthRelay StealthRelay;
 PLUGINLIB_EXPORT_CLASS(StealthRelay, nodelet::Nodelet)

--- a/jsk_topic_tools/src/string_relay_nodelet.cpp
+++ b/jsk_topic_tools/src/string_relay_nodelet.cpp
@@ -60,6 +60,6 @@ namespace jsk_topic_tools
   }
 }
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 typedef jsk_topic_tools::StringRelay StringRelay;
 PLUGINLIB_EXPORT_CLASS(StringRelay, nodelet::Nodelet)

--- a/jsk_topic_tools/src/synchronized_throttle_nodelet.cpp
+++ b/jsk_topic_tools/src/synchronized_throttle_nodelet.cpp
@@ -66,7 +66,7 @@ void SynchronizedThrottle::onInit()
 
   srv_ = boost::make_shared<dynamic_reconfigure::Server<Config> >(*pnh_);
   dynamic_reconfigure::Server<Config>::CallbackType f =
-      boost::bind(&SynchronizedThrottle::configCallback, this, _1, _2);
+      [this](auto& config, auto level){ configCallback(config, level); };
   srv_->setCallback(f);
 
   // message_filter supports 2~8 input topics
@@ -89,7 +89,7 @@ void SynchronizedThrottle::onInit()
   {
     check_sub_[i] = pnh_->subscribe<topic_tools::ShapeShifterStamped>(
         input_topics_[i], 1,
-        boost::bind(&SynchronizedThrottle::checkCallback, this, _1, i));
+        [this,i](auto& msg){ checkCallback(msg, i); });
     sub_[i].reset(new message_filters::Subscriber<topic_tools::ShapeShifterStamped>());
   }
 
@@ -178,7 +178,7 @@ void SynchronizedThrottle::subscribe()
   if (n_topics < MAX_SYNC_NUM)
   {
     sub_[0]->registerCallback(
-        boost::bind(&SynchronizedThrottle::fillNullMessage, this, _1));
+        [this](auto& msg){ fillNullMessage(msg); });
   }
 
   if (approximate_sync_)
@@ -220,8 +220,16 @@ void SynchronizedThrottle::subscribe()
         return;
     }
     async_->registerCallback(
-        boost::bind(&SynchronizedThrottle::inputCallback, this,
-                    _1, _2, _3, _4, _5, _6, _7, _8));
+         boost::bind(&SynchronizedThrottle::inputCallback, this,
+                     boost::placeholders::_1,
+                     boost::placeholders::_2,
+                     boost::placeholders::_3,
+                     boost::placeholders::_4,
+                     boost::placeholders::_5,
+                     boost::placeholders::_6,
+                     boost::placeholders::_7,
+                     boost::placeholders::_8));
+
   } else {
     sync_ = boost::make_shared<message_filters::Synchronizer<SyncPolicy> >(queue_size_);
 
@@ -260,8 +268,15 @@ void SynchronizedThrottle::subscribe()
         return;
     }
     sync_->registerCallback(
-        boost::bind(&SynchronizedThrottle::inputCallback, this,
-                    _1, _2, _3, _4, _5, _6, _7, _8));
+         boost::bind(&SynchronizedThrottle::inputCallback, this,
+                     boost::placeholders::_1,
+                     boost::placeholders::_2,
+                     boost::placeholders::_3,
+                     boost::placeholders::_4,
+                     boost::placeholders::_5,
+                     boost::placeholders::_6,
+                     boost::placeholders::_7,
+                     boost::placeholders::_8));
   }
 }
 

--- a/jsk_topic_tools/src/synchronized_throttle_nodelet.cpp
+++ b/jsk_topic_tools/src/synchronized_throttle_nodelet.cpp
@@ -427,6 +427,6 @@ void SynchronizedThrottle::inputCallback(
 
 } // jsk_topic_tools
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 typedef jsk_topic_tools::SynchronizedThrottle SynchronizedThrottle;
 PLUGINLIB_EXPORT_CLASS(SynchronizedThrottle, nodelet::Nodelet)

--- a/jsk_topic_tools/src/tests/test_log_utils_nodelet.cpp
+++ b/jsk_topic_tools/src/tests/test_log_utils_nodelet.cpp
@@ -45,5 +45,5 @@ private:
 
 }  // namespace jsk_topic_tools
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(jsk_topic_tools::test::LogUtils, nodelet::Nodelet)

--- a/jsk_topic_tools/src/timered_diagnostic_updater.cpp
+++ b/jsk_topic_tools/src/timered_diagnostic_updater.cpp
@@ -43,10 +43,7 @@ namespace jsk_topic_tools
     diagnostic_updater_(new diagnostic_updater::Updater)
   {
     timer_ = nh.createTimer(
-      timer_duration, boost::bind(
-        &TimeredDiagnosticUpdater::timerCallback,
-        this,
-        _1));
+      timer_duration, [this](auto& event){ timerCallback(event); });
     timer_.stop();
   }
   

--- a/jsk_topic_tools/src/topic_buffer_client.cpp
+++ b/jsk_topic_tools/src/topic_buffer_client.cpp
@@ -200,7 +200,8 @@ int main(int argc, char **argv)
         pub_info->advertised = false;
         pub_info->topic_with_header = false;
         ROS_INFO_STREAM("subscribe " << pub_info->topic_name+string("_update"));
-        pub_info->sub = new ros::Subscriber(n.subscribe<ShapeShifter>(pub_info->topic_name+string("_update"), 10, boost::bind(in_cb, _1, pub_info)));
+        pub_info->sub = new ros::Subscriber(n.subscribe<ShapeShifter>(pub_info->topic_name+string("_update"), 10,
+            [pub_info](auto& msg){ in_cb(msg, pub_info); }));
 
         g_pubs.push_back(pub_info);
     }

--- a/jsk_topic_tools/src/topic_buffer_server.cpp
+++ b/jsk_topic_tools/src/topic_buffer_server.cpp
@@ -219,7 +219,7 @@ int main(int argc, char **argv)
             sub_info->advertised = false;
             sub_info->periodic = false;
             ROS_INFO_STREAM("subscribe " << sub_info->topic_name);
-            sub_info->sub = new ros::Subscriber(n.subscribe<ShapeShifter>(sub_info->topic_name, 10, boost::bind(in_cb, _1, sub_info)));
+            sub_info->sub = new ros::Subscriber(n.subscribe<ShapeShifter>(sub_info->topic_name, 10, [sub_info](auto& msg){ in_cb(msg, sub_info); }));
 
             // waiting for all topics are publisherd
             while (sub_info->sub->getNumPublishers() == 0 ) {

--- a/jsk_topic_tools/src/vital_checker_nodelet.cpp
+++ b/jsk_topic_tools/src/vital_checker_nodelet.cpp
@@ -86,6 +86,6 @@ namespace jsk_topic_tools
   }
 }
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 typedef jsk_topic_tools::VitalCheckerNodelet VitalCheckerNodelet;
 PLUGINLIB_EXPORT_CLASS(VitalCheckerNodelet, nodelet::Nodelet)


### PR DESCRIPTION
it break with current log4cxx which requires c++17. No, going forward it's no option to specify the standard anymore. And it's not necessary either.

@k-okada 