### PR TITLE
[jsk_data/download_data.py] Add timeout argument to download() for wget

### DIFF
--- a/jsk_data/src/jsk_data/download_data.py
+++ b/jsk_data/src/jsk_data/download_data.py
@@ -96,20 +96,26 @@ def decompress_rosbag(path, quiet=False, chmod=True):
     print('[%s] Finished decompressing the rosbag' % path)
 
 
-def download(client, url, output, quiet=False, chmod=True):
+def download(client, url, output, quiet=False, chmod=True, timeout=30):
     print('[%s] Downloading from %s' % (output, url))
-    cmd = '{client} {url} -O {output}'.format(client=client, url=url,
-                                              output=output)
+    if client == 'wget':
+        cmd = '{client} {url} -O {output} -T {timeout} --tries 1'.format(client=client, url=url,
+                                                                         output=output, timeout=timeout)
+    else:
+        cmd = '{client} {url} -O {output}'.format(client=client, url=url,
+                                                  output=output)
     if quiet:
         cmd += ' --quiet'
     try:
-        subprocess.call(shlex.split(cmd))
+        status = subprocess.call(shlex.split(cmd))
     finally:
         if chmod:
             if not is_file_writable(output):
                 os.chmod(output, 0o766)
-    print('[%s] Finished downloading' % output)
-
+    if status == 0:
+        print('[%s] Finished downloading' % output)
+    else:
+        print('[%s] Failed downloading. exit_status: %d' % (output, status))
 
 def check_md5sum(path, md5):
     # validate md5 string length if it is specified


### PR DESCRIPTION
The build of jsk_pcl_ros does not terminate because torus.pcd is inaccessible.
https://github.com/jsk-ros-pkg/jsk_recognition/blob/62facef973dd8a54e179c90b514ea54c8b0fdd83/jsk_pcl_ros/scripts/install_sample_data.py#L130-L135
wget timeout is 900s and tries is 20 by default, so we have to wait for the end for 5 hours.

This PR sets default timeout=30 and fixes tries=1.
When verbose is false,  we can tell the cause of failure as follows.
```
$ roscd jsk_pcl_ros
$ python scripts/install_sample_data.py
```
```
[/home/nakane/.ros/data/jsk_pcl_ros/torus.pcd] Failed downloading. exit_status: 4
[/home/nakane/.ros/data/jsk_pcl_ros/torus.pcd] checking md5sum)
[/home/nakane/.ros/data/jsk_pcl_ros/torus.pcd] Finished checking md5sum
[/home/nakane/.ros/data/jsk_pcl_ros/torus.pcd] Downloading from https://blog.innovotion.co.jp/wp-content/uploads/2018/08/torus.pcd
[/home/nakane/.ros/data/jsk_pcl_ros/torus.pcd] Failed downloading. exit_status: 4
[/home/nakane/.ros/data/jsk_pcl_ros/torus.pcd] md5sum mismatched! expected: 17ae9636f42403a20bf1b936c03bb35c vs actual: d41d8cd98f00b204e9800998ecf8427e
```
cc @iory 
