### PR TITLE
use setuptools over distutils

### DIFF
--- a/jsk_common/package.xml
+++ b/jsk_common/package.xml
@@ -19,7 +19,7 @@
   <exec_depend>audio_video_recorder</exec_depend>
   <exec_depend>dynamic_tf_publisher</exec_depend>
   <exec_depend>image_view2</exec_depend>
-  <exec_depend>jsk_rosbag_tools</exec_depend>
+  <!--<exec_depend>jsk_rosbag_tools</exec_depend>-->
   <exec_depend>jsk_topic_tools</exec_depend>
   <exec_depend>jsk_tools</exec_depend>
   <exec_depend>multi_map_server</exec_depend>


### PR DESCRIPTION
Sorry, I missed those in the last set of patches.

setup from distutils is deprecated and will be removed eventually. It already breaks on Debian testing.