### PR TITLE
[jsk_rosbag_tools] set python_interpreter python2 for melodic, install scipy<1.9.0+numpy>=1.21.0 for python3  and apt scipy+numpy<1.21.0 for python2

### DIFF
--- a/jsk_rosbag_tools/CMakeLists.txt
+++ b/jsk_rosbag_tools/CMakeLists.txt
@@ -26,6 +26,7 @@ if($ENV{ROS_DISTRO} STREQUAL "noetic")
 else()
   catkin_generate_virtualenv(
     INPUT_REQUIREMENTS requirements.in.python2
+    PYTHON_INTERPRETER python2
   )
 endif()
 

--- a/jsk_rosbag_tools/CMakeLists.txt
+++ b/jsk_rosbag_tools/CMakeLists.txt
@@ -25,7 +25,7 @@ if($ENV{ROS_DISTRO} STREQUAL "noetic")
   )
 else()
   catkin_generate_virtualenv(
-    INPUT_REQUIREMENTS requirements.in
+    INPUT_REQUIREMENTS requirements.in.python2
   )
 endif()
 

--- a/jsk_rosbag_tools/requirements.in
+++ b/jsk_rosbag_tools/requirements.in
@@ -1,1 +1,3 @@
 moviepy==1.0.3
+scipy
+numpy

--- a/jsk_rosbag_tools/requirements.in
+++ b/jsk_rosbag_tools/requirements.in
@@ -1,2 +1,3 @@
 moviepy==1.0.3
 scipy<1.9.0
+numpy>=1.21.0

--- a/jsk_rosbag_tools/requirements.in
+++ b/jsk_rosbag_tools/requirements.in
@@ -1,3 +1,3 @@
 moviepy==1.0.3
-scipy
+scipy<1.9.0
 numpy

--- a/jsk_rosbag_tools/requirements.in.python2
+++ b/jsk_rosbag_tools/requirements.in.python2
@@ -1,2 +1,2 @@
 moviepy==1.0.3
-scipy<1.9.0
+numpy<1.21.0


### PR DESCRIPTION
this PR solves #1780 
`typeDict` is deprecated in `numpy>=1.21.0` in `scipy`

For python3, I install `scipy` in `catkin_virtualenv` to upgrade `scipy`.
https://stackoverflow.com/questions/74852225/attributeerror-module-numpy-has-no-attribute-typedict/74969328#74969328

scipy version should be `1.9.0` because of `openblas` problem with `meson`.
https://github.com/scipy/scipy/issues/16308

For python2, I install `numpy<1.21.0` to avoid attribute error.

So I made two requirements for `python2` and `python3`.
- python3:
  - `scipy<1.9.0` (because of meson build error)
  - `numpy>=1.21.0` (scipy requires this version)
- python2
  - `scipy` from apt
  - `numpy<1.21.0`(because of typeDict attribute error)

this PR also specify the python interpreter as `python2` for melodic.