### PR TITLE
[jsk_rosbag_tools] Use python3-catkin-pkg-modules when python3 is used

### DIFF
--- a/jsk_rosbag_tools/package.xml
+++ b/jsk_rosbag_tools/package.xml
@@ -9,7 +9,8 @@
   <author email="yanokura@jsk.imi.i.u-tokyo.ac.jp">Iori Yanokura</author>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <buildtool_depend>python-catkin-pkg-modules</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-catkin-pkg-modules</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-catkin-pkg-modules</buildtool_depend>
 
   <build_depend version_gte="0.5.1">catkin_virtualenv</build_depend>
 


### PR DESCRIPTION
In noetic, the following error occurred when I executed `rosdep install`.
This PR avoids this error.

```
tsukamoto@tsukamoto-desktop-ryzen ~/ros/fetch_ws/src/jsk-ros-pkg/jsk_common/jsk_rosbag_tools (develop/fetch %=) 
$ rosdep install -y -r --from-paths . --ignore-src
executing command [sudo -H apt-get install -y python-catkin-pkg-modules]
パッケージリストを読み込んでいます... 完了
依存関係ツリーを作成しています                
状態情報を読み取っています... 完了
E: パッケージ python-catkin-pkg-modules が見つかりません
ERROR: the following rosdeps failed to install
  apt: command [sudo -H apt-get install -y python-catkin-pkg-modules] failed
  apt: Failed to detect successful installation of [python-catkin-pkg-modules]

```