### PR TITLE
Add sample audio_recorder

### DIFF
--- a/audio_video_recorder/launch/audio_recorder.launch
+++ b/audio_video_recorder/launch/audio_recorder.launch
@@ -1,0 +1,19 @@
+<launch>
+  <arg name="audio_topic_name" />
+  <arg name="queue_size" />
+  <arg name="file_name" />
+  <arg name="channels" />
+  <arg name="depth" />
+  <arg name="sample_rate" />
+
+  <node name="audio_recorder" pkg="audio_video_recorder"
+        type="audio_recorder.py" output="screen">
+    <remap from="~input/audio" to="$(arg audio_topic_name)" />
+    <rosparam subst_value="true">
+      file_name: $(arg file_name)
+      channels: $(arg channels)
+      depth: $(arg depth)
+      sample_rate: $(arg sample_rate)
+    </rosparam>
+  </node>
+</launch>

--- a/audio_video_recorder/sample/sample_audio_recorder.launch
+++ b/audio_video_recorder/sample/sample_audio_recorder.launch
@@ -1,0 +1,25 @@
+<launch>
+  <arg name="file_name" default="/tmp/test_audio.wav" />
+  <arg name="channels" default="1" />
+  <arg name="depth" default="16" />
+  <arg name="sample_rate" default="16000" />
+  <arg name="sample_format" default="S16LE" />
+  <arg name="device" default="" />
+  <arg name="format" default="wave" />
+
+  <include file="$(find audio_capture)/launch/capture.launch">
+    <arg name="format" value="$(arg format)" />
+    <arg name="channels" value="$(arg channels)" />
+    <arg name="depth" value="$(arg depth)" />
+    <arg name="sample_rate" value="$(arg sample_rate)" />
+    <arg name="sample_format" value="$(arg sample_format)" />
+  </include>
+
+  <include file="$(find audio_video_recorder)/launch/audio_recorder.launch">
+    <arg name="audio_topic_name" value="/audio/audio" />
+    <arg name="file_name" value="$(arg file_name)" />
+    <arg name="channels" value="$(arg channels)" />
+    <arg name="depth" value="$(arg depth)" />
+    <arg name="sample_rate" value="$(arg sample_rate)" />
+  </include>
+</launch>

--- a/audio_video_recorder/scripts/audio_recorder.py
+++ b/audio_video_recorder/scripts/audio_recorder.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+import rospy
+from audio_common_msgs.msg import AudioData
+import wave
+import time
+
+class AudioRecorder:
+    def __init__(self):
+        rospy.init_node('audio_recorder', anonymous=True)
+        self.channels = rospy.get_param('~channels', 1)
+        self.depth = rospy.get_param('~depth', 16)
+        self.sample_rate = rospy.get_param('~sample_rate', 16000)
+        self.audio_data = bytearray()
+        self.start_time = None
+        self.save_path = rospy.get_param('~file_name', "/tmp/recorded_wave_audio.wav")
+        print(self.save_path)
+
+        self.audio_sub = rospy.Subscriber('~input/audio', AudioData, self.audio_callback)
+        rospy.loginfo("Waiting for audio topic ...")
+
+    def audio_callback(self, data):
+        if self.start_time is None:
+            self.start_time = time.time()
+            rospy.loginfo("Recording audio.")
+
+        self.audio_data.extend(data.data)
+        self.save_audio_data()
+
+    def save_audio_data(self):
+        with wave.open(self.save_path, 'wb') as wf:
+            wf.setnchannels(self.channels)
+            wf.setsampwidth(self.depth // 8)
+            wf.setframerate(self.sample_rate)
+
+            wf.writeframes(self.audio_data)
+
+def main():
+
+    recorder = AudioRecorder()
+
+    rospy.spin()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
If you want an audio file, [capture_to_file.launch  of audio_capture](https://github.com/ros-drivers/audio_common/blob/master/audio_capture/launch/capture_to_file.launch) is effective. However, since the audio topic is not published by capture_to_file.launch, a program that saves the audio topic to a file is required to simultaneously publish the topic and save the real-time audio file.

The people at https://stackoverflow.com/questions/63145510/how-to-write-ros-audiodata-message-into-wav-file are also looking for it, and there doesn't seem to be one, so I wrote a simple sample.  

If there is a demand and we need to do it properly, maybe we should understand gstreamer and split audio_video_recorder into audio only or video only (not many programs can make rostopic into a video with proper time?), or make it by bringing a part of `jsk_rosbag_tools` as a function. 