### PR TITLE
[doc] Fix jsk_topic_tools/Passthrough doc Usage section

### DIFF
--- a/doc/jsk_topic_tools/lib/passthrough_nodelet.md
+++ b/doc/jsk_topic_tools/lib/passthrough_nodelet.md
@@ -40,13 +40,13 @@
 $ roslaunch jsk_topic_tools passthrough_sample.launch
 
 # Terminal 2
-$ rostopic pub /passthrough_sample/input std_msgs/String "data: 'hello'" -r10
+$ rostopic pub /input std_msgs/String "data: 'hello'" -r10
 
 # Terminal 3
-$ rostopic echo /passthrough_sample/input
+$ rostopic echo /input
 
 # Terminal 4
-$ rostopic echo /passthrough_sample/output
+$ rostopic echo /output
 
 # Terminal 5
 $ rosservice call /passthrough_sample/request


### PR DESCRIPTION
This PR fixes jsk_topic_tools/Passthrough documentation.

In https://github.com/jsk-ros-pkg/jsk_common/blob/78faabe470fe02567e215a05a752e7c1d97e16a6/jsk_topic_tools/launch/passthrough_sample.launch  , 
remap topic uses `~` something like '~input', so input topic and output topic don't have a namespace from the node name.