### PR TITLE
[jsk_rosbag_tools] Fixed pillow version

### DIFF
--- a/jsk_rosbag_tools/requirements.in
+++ b/jsk_rosbag_tools/requirements.in
@@ -1,3 +1,4 @@
+Pillow==8.4.0
 moviepy==1.0.3
 scipy<1.9.0
 numpy>=1.21.0


### PR DESCRIPTION
Related to #1798 

In the course of addressing a build failure related to dependency resolution within our `jsk_rosbag_tools` package, we encountered an error indicating that `pip-compile` was unable to properly identify the version of the `Pillow` package required by `imageio==2.34.0` as part of the `moviepy==1.0.3` dependency. The error specifically pointed out that the package name or version was not recognized properly, which led to a halt in the dependency resolution process and subsequently the build process.

To resolve this issue, we've explicitly pinned the `Pillow` version to `8.4.0` in the `requirements.in` file. This action was taken after thoroughly investigating the underlying problem, which suggested that an explicit declaration could help `pip-compile` in resolving the correct package version and thus, facilitate a smoother dependency resolution process. Here's the commit that addresses this problem:

