### PR TITLE
use catkin_install_python to install python scripts

### DIFF
--- a/jsk_network_tools/CMakeLists.txt
+++ b/jsk_network_tools/CMakeLists.txt
@@ -63,7 +63,14 @@ add_dependencies(silverhammer_highspeed_internal_receiver
 # recursively into ${CATKIN_PACKAGE_SHARE_DESTINATION}.
 # Be careful that 'launch' and 'launch/' are different: the former is directory
 # and the latter is each content.
-install(DIRECTORY scripts/
+
+file(GLOB PYTHON_SCRIPTS scripts/*.py)
+catkin_install_python(
+  PROGRAMS ${PYTHON_SCRIPTS}
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+install(
+  PROGRAMS scripts/expand_udp_receive_buffer.sh
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
   USE_SOURCE_PERMISSIONS
 )

--- a/jsk_topic_tools/CMakeLists.txt
+++ b/jsk_topic_tools/CMakeLists.txt
@@ -243,7 +243,15 @@ install(DIRECTORY include/${PROJECT_NAME}/
   FILES_MATCHING PATTERN "*.h" # Ignore *_version.h.in files
 )
 
-install(DIRECTORY scripts/
+file(GLOB PYTHON_SCRIPTS scripts/*.py)
+list(APPEND PYTHON_SCRIPTS is_synchronized rostopic_connection_list)
+catkin_install_python(
+  PROGRAMS ${PYTHON_SCRIPTS}
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(
+  PROGRAMS sample_topic_update_caller.sh
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
   USE_SOURCE_PERMISSIONS
 )


### PR DESCRIPTION
To fix the error `/usr/bin/env: ‘python’: No such file or directory`