### PR TITLE
[jsk_data] Automatically add the host key and Check stdout.read() type

### DIFF
--- a/jsk_data/src/jsk_data/cli.py
+++ b/jsk_data/src/jsk_data/cli.py
@@ -83,7 +83,11 @@ def _list_aries_files(query=None, ls_options=None):
         cmd = 'ls {opt} {dir}/private/{q}'
         cmd = cmd.format(opt=' '.join(ls_options), dir=DATA_DIR, q=query)
         _, stdout, _ = ssh.exec_command(cmd)
-        files = stdout.read().splitlines()
+        output = stdout.read()
+        if isinstance(output, bytes):  # Python 3
+            files = output.decode('utf-8').splitlines()
+        else:
+            files = output.splitlines()
     return files
 
 

--- a/jsk_data/src/jsk_data/ssh.py
+++ b/jsk_data/src/jsk_data/ssh.py
@@ -16,6 +16,7 @@ def _connect_ssh_context(host, username, password):
     try:
         ssh = paramiko.SSHClient()
         ssh.load_host_keys(os.path.expanduser('~/.ssh/known_hosts'))
+        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())  # Automatically add the host key
         ssh.connect(host, username=username, password=password)
         yield ssh
     finally:


### PR DESCRIPTION
- stdout.read() returns a bytes object in Python 3, whereas in Python 2, it returned a str
-
The error indicates that the new version of Paramiko (2.6.0) is stricter about host key checking, requiring the server to be present in the known_hosts file by default. This is a security feature to prevent man-in-the-middle attacks.

Closes #1792