### PR TITLE
[ROS-O] Skip non-existent python dependencies

### DIFF
--- a/jsk_tools/package.xml
+++ b/jsk_tools/package.xml
@@ -25,13 +25,13 @@
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-colorama</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-colorama</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-github</exec_depend> <!-- python-pygithub3 (pip pygithub3) requres python3-github -->
-  <exec_depend>python-pygithub3</exec_depend>
+  <exec_depend condition="$ROS_DISTRO != 'one'">python-pygithub3</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-progressbar</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-progressbar</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-rosdep</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rosdep</exec_depend>
-  <exec_depend>python-slacker-cli</exec_depend>
-  <exec_depend>python-tabulate-pip</exec_depend>
+  <exec_depend condition="$ROS_DISTRO != 'one'">python-slacker-cli</exec_depend>
+  <exec_depend condition="$ROS_DISTRO != 'one'">python-tabulate-pip</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-tabulate</exec_depend> <!-- python-tabulate enable since xenial (16.04) kinetic -->
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-tabulate</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-texttable</exec_depend>


### PR DESCRIPTION
Currently, the `ros-one-jsk-common` apt package is not installable (At least on Ubuntu 24.04) due to insufficient dependencies on installing `jsk_tools`:

```
$ sudo apt install ros-one-jsk-common
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 ros-one-jsk-common : Depends: ros-one-jsk-tools but it is not going to be installed
                      Depends: ros-one-multi-map-server but it is not installable
E: Unable to correct problems, you have held broken packages.

$ sudo apt install ros-one-jsk-tools
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 ros-one-jsk-tools : Depends: pygithub3 but it is not installable
                     Depends: slacker-cli but it is not installable
                     Depends: tabulate but it is not installable
E: Unable to correct problems, you have held broken packages
```

This PR is for skipping some non-existent dependencies from `package.xml` for ROS-O distro.
- python-pygithub3 -> Non existent
- python-slacker-cli -> Non existent
- python-tabulate-pip -> There is also `python3-tabulate` in the package.xml, is it enough?