### PR TITLE
update jsk_travis 0.5.28 (new ROS repository key)

### DIFF
--- a/jsk_rosbag_tools/requirements.in.python2
+++ b/jsk_rosbag_tools/requirements.in.python2
@@ -1,2 +1,3 @@
+proglog==0.1.11
 moviepy==1.0.3
 numpy<1.21.0


### PR DESCRIPTION
update jsk_travis and fix error on `jsk_rosbag_tools/requirements.in.python2`, Working installed pip packages as follows.
```
  certifi==2025.7.14        # via requests
  charset-normalizer==3.4.2  # via requests
  decorator==4.4.2          # via moviepy
  idna==3.10                # via requests
  imageio-ffmpeg==0.5.1     # via moviepy
  imageio==2.35.1           # via moviepy
  moviepy==1.0.3            # via -r requirements.in
  numpy==1.24.4             # via -r requirements.in, imageio, moviepy, scipy
  pillow==8.4.0             # via -r requirements.in, imageio
  proglog==0.1.12           # via moviepy
  requests==2.32.4          # via moviepy
  scipy==1.8.1              # via -r requirements.in
  tqdm==4.67.1              # via moviepy, proglog
  urllib3==2.2.3            # via requests
  ```