### PR TITLE
GA: use git from ubuntu system instead of ppa:git-core/ppa

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -42,14 +42,20 @@ jobs:
 
     container:
       image: ${{ matrix.CONTAINER }}
-      volumes:
-        - /tmp/node20:/__e/node20
 
     steps:
-      - name: Install latest git ( use sudo for ros-ubuntu )
+      - name: Install git
+        shell: bash
         run: |
-          (apt-get update && apt-get install -y sudo) || echo "OK"
-          sudo apt-get update && sudo apt-get install -y software-properties-common && sudo apt-get update && sudo add-apt-repository -y ppa:git-core/ppa && sudo apt-get update && sudo apt-get install -y git
+          set -eux
+          export DEBIAN_FRONTEND=noninteractive
+          if [ "${{ matrix.CONTAINER }}" != "jskrobotics/ros-ubuntu:14.04" ]; then
+            apt-get update
+            apt-get install -y -qq sudo
+          fi
+          sudo apt-get update
+          sudo apt-get update -o Acquire::Retries=3
+          sudo apt-get install -y --no-install-recommends git ca-certificates
 
       - name: work around permission issue  # https://github.com/actions/checkout/issues/760#issuecomment-1097501613
         run: |
@@ -67,23 +73,14 @@ jobs:
              git config --global --add safe.directory $GITHUB_WORKSPACE
           fi
 
-      - name: Try to replace `node` with an glibc 2.17
+      - name: Checkout repository without Node.js
         shell: bash
         run: |
-          if [ "${{ matrix.CONTAINER }}" = "jskrobotics/ros-ubuntu:14.04" ]; then
-             export USER=$(whoami)
-             sudo chmod 777 -R /__e/node20
-             sudo chown -R $USER /__e/node20
-          fi
-          ls -lar /__e/node20 &&
-          sudo apt-get install -y curl &&
-          curl -Lo /tmp/node.tar.gz https://unofficial-builds.nodejs.org/download/release/v20.17.0/node-v20.17.0-linux-x64-glibc-217.tar.gz &&
-          cd /__e/node20 &&
-          tar -x --strip-components=1 -f /tmp/node.tar.gz &&
-          ls -lar /__e/node20/bin/
-
-      - name: Chcekout
-        uses: actions/checkout@v3.0.2
+          set -eux
+          git init .
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git fetch --no-tags --prune --depth=1 origin "${GITHUB_REF}"
+          git checkout --detach FETCH_HEAD
 
       - name: Start X server
         run: |

--- a/.github/workflows/python2.yml
+++ b/.github/workflows/python2.yml
@@ -14,8 +14,8 @@ jobs:
     container: ubuntu:20.04
 
     steps:
-      - name: Install latest git to download .git directory in actions/checkout@v2 ( use sudo for ros-ubuntu )
-        run: apt-get update && apt-get install -y software-properties-common && apt-get update && add-apt-repository -y ppa:git-core/ppa && apt-get update && apt-get install -y git
+      - name: Install git
+        run: apt-get update && apt-get install -y --no-install-recommends git ca-certificates
       - name: Chcekout
         uses: actions/checkout@v2
       - name: Check Python2

--- a/.github/workflows/python3.yml
+++ b/.github/workflows/python3.yml
@@ -10,8 +10,8 @@ jobs:
     container: ubuntu:20.04
 
     steps:
-      - name: Install latest git to download .git directory in actions/checkout@v2 ( use sudo for ros-ubuntu )
-        run: apt-get update && apt-get install -y software-properties-common && apt-get update && add-apt-repository -y ppa:git-core/ppa && apt-get update && apt-get install -y git
+      - name: Install git
+        run: apt-get update && apt-get install -y --no-install-recommends git ca-certificates
       - name: work around permission issue  # https://github.com/actions/checkout/issues/760#issuecomment-1097501613
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: Chcekout


### PR DESCRIPTION
## Summary
- The "Install latest git" step in the `ros` job relied on `ppa:git-core/ppa`, which has been failing intermittently on Launchpad, breaking CI
- Applied the same fix as jsk_3rdparty (jsk-ros-pkg/jsk_3rdparty@8b356d5e):
  - Install `git` from the Ubuntu system repository instead of `ppa:git-core/ppa`
  - Replace the Node.js-dependent `actions/checkout` (which needed the glibc 2.17 workaround for `jskrobotics/ros-ubuntu:14.04`) with a plain `git init`/`fetch`/`checkout --detach`
  - Remove the now-unneeded `/tmp/node20:/__e/node20` volume mount

## Test plan
- [ ] Confirm the `ros` job is green across all distros in GitHub Actions, including indigo (jskrobotics/ros-ubuntu:14.04)

https://claude.ai/code/session_01SQVZSMgGb58qGyCtWt5UJB
